### PR TITLE
Add workflow for publishing to pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,43 @@
+name: pypi
+
+on:
+  push:
+    branches: [main]
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install build and twine
+      run: |
+        python -m pip install build twine
+
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python3 -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -23,13 +23,13 @@ jobs:
 
     - name: Install pypa/build
       run: >-
-        python3 -m
-        pip install
+        python -m
+        python -m pip install
         build
 
     - name: Build a binary wheel and a source tarball
       run: >-
-        python3 -m
+        python -m
         build
         --sdist
         --wheel


### PR DESCRIPTION
Add simple workflow for upload package to PyPI based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

Note: need to set `PYPI_API_TOKEN` under Settings -> Security -> Secrets and variables -> Action to make it work