### PR TITLE
Use trusted publisher management when publishing to pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,31 +7,33 @@ on:
       - "v*"
 
 jobs:
-  build:
-
+  dist:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
+
+    - name: Build SDist and wheel
+      run: pipx run build
+
+    - uses: actions/upload-artifact@v3
       with:
-        python-version: "3.10"
-    - name: Install build and twine
-      run:
-        python -m pip install build twine
+        path: dist/*
 
+    - name: Check metadata
+      run: pipx run twine check dist/*
 
-    - name: Install pypa/build
-      run:
-        python -m pip install build
+  publish:
+    needs: [dist]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    environment: pypi
+    permissions:
+      id-token: write
 
-    - name: Build a binary wheel and a source tarball
-      run:
-        python -m build --sdist --wheel --outdir dist/ .
-
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+    steps:
+    - uses: actions/download-artifact@v3
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
There is a new way to publish packages to pypi using something called *trusted publishers*. You can read more about this here: https://docs.pypi.org/trusted-publishers/

Here I am adopting the workflow from [cibuildwheel](https://github.com/pypa/cibuildwheel/blob/main/.github/workflows/release.yml) which I belive is based on the [following article](https://learn.scientific-python.org/development/guides/gha-wheels/) (which by the way is a great resource).

Note that I have also added GitHub as a trusted publisher as outlined [here](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) see screenshot
![Screenshot 2023-08-11 at 11 01 09](https://github.com/jorgensd/adios4dolfinx/assets/2010323/d02513fa-ff80-4bce-ab19-8c17b6315efc)
