### PR TITLE
Update legacy image and fix numpy asarray

### DIFF
--- a/.github/workflows/create_legacy_data.yml
+++ b/.github/workflows/create_legacy_data.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   create-data:
     runs-on: "ubuntu-22.04"
-    container: ghcr.io/scientificcomputing/fenics-gmsh:jupterlab-2023-11-15
+    container: ghcr.io/scientificcomputing/fenics:2023-11-15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/create_legacy_data.yml
+++ b/.github/workflows/create_legacy_data.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   create-data:
     runs-on: "ubuntu-22.04"
-    container: ghcr.io/scientificcomputing/fenics-gmsh:jupterlab-2023-08-31
+    container: ghcr.io/scientificcomputing/fenics-gmsh:jupterlab-2023-11-15
     steps:
       - uses: actions/checkout@v4
 

--- a/src/adios4dolfinx/adios2_helpers.py
+++ b/src/adios4dolfinx/adios2_helpers.py
@@ -165,8 +165,8 @@ def read_dofmap(
 
 
 def read_array(
-            adios: adios2.adios2.ADIOS,
-            filename: pathlib.Path, array_name: str, engine: str, comm: MPI.Intracomm
+    adios: adios2.adios2.ADIOS,
+    filename: pathlib.Path, array_name: str, engine: str, comm: MPI.Intracomm
 ) -> Tuple[npt.NDArray[valid_function_types], int]:
     """
     Read an array from file, return the global starting position of the local array
@@ -203,9 +203,10 @@ def read_array(
     else:
         arr.SetSelection([[arr_range[0], 0], [arr_range[1] - arr_range[0], arr_shape[1]]])
         vals = np.empty((arr_range[1] - arr_range[0], arr_shape[1]), dtype=adios_to_numpy_dtype[arr.Type()])
+        assert arr_shape[1] == 1
 
     infile.Get(arr, vals, adios2.Mode.Sync)
     infile.EndStep()
     infile.Close()
     adios.RemoveIO("ArrayReader")
-    return vals, arr_range[0]
+    return vals.reshape(-1), arr_range[0]

--- a/src/adios4dolfinx/checkpointing.py
+++ b/src/adios4dolfinx/checkpointing.py
@@ -222,11 +222,13 @@ def read_function(u: dolfinx.fem.Function, filename: Path, engine: str = "BP4"):
         # First invert input data to reference element then transform to current mesh
         for i, l_cell in enumerate(input_local_cell_index):
             start, end = input_dofmap.offsets[l_cell], input_dofmap.offsets[l_cell + 1]
+            # FIXME: Tempoary cast uint32 to integer as transformations doesn't support uint32 with the switch
+            # to nanobind
             element.apply_transpose_dof_transformation(
-                recv_array[start:end], input_perms[l_cell], bs
+                recv_array[start:end], int(input_perms[l_cell]), bs
             )
             element.apply_inverse_transpose_dof_transformation(
-                recv_array[start:end], inc_perms[i], bs
+                recv_array[start:end], int(inc_perms[i]), bs
             )
     # ------------------Step 6----------------------------------------
     # For each dof owned by a process, find the local position in the dofmap.

--- a/src/adios4dolfinx/checkpointing.py
+++ b/src/adios4dolfinx/checkpointing.py
@@ -123,9 +123,9 @@ def write_mesh(mesh: dolfinx.mesh.Mesh, filename: Path, engine: str = "BP4"):
 
     dofs_out = np.zeros((num_cells_local, num_dofs_per_cell), dtype=np.int64)
     assert g_dmap.shape[1] == num_dofs_per_cell
-    dofs_out[:, :] = g_imap.local_to_global(
+    dofs_out[:, :] = np.asarray(g_imap.local_to_global(
         g_dmap[:num_cells_local, :].reshape(-1)
-    ).reshape(dofs_out.shape)
+    )).reshape(dofs_out.shape)
 
     dvar = io.DefineVariable(
         "Topology",

--- a/src/adios4dolfinx/legacy_readers.py
+++ b/src/adios4dolfinx/legacy_readers.py
@@ -109,9 +109,11 @@ def read_dofmap_legacy(
         in_dofmap = np.empty(
             (in_offsets[-1] - in_offsets[0], shape[1]), dtype=cell_dofs.Type().strip("_t")
         )
+        assert shape[1] == 1
+
     infile.Get(cell_dofs, in_dofmap, adios2.Mode.Sync)
 
-    in_dofmap = in_dofmap.astype(np.int64)
+    in_dofmap = in_dofmap.reshape(-1).astype(np.int64)
 
     # Map xxxyyyzzz to xyzxyz
     mapped_dofmap = np.empty_like(in_dofmap)


### PR DESCRIPTION
Temporary edit integer type passed to transformation function, as there is no way of passing down a numpy uint32_t through nanobind