### PR TITLE
Add `numba` to required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Wrappers for reading/writing DOLFINx meshes/functions with ADIOS2
 authors = [{ name = "Jørgen S. Dokken", email = "dokken@simula.no" }]
 license = { file = "LICENSE" }
 readme = "README.md"
-dependencies = ["fenics-dolfinx>0.7.0"]
+dependencies = ["fenics-dolfinx>0.7.0", "numba"]
 
 [project.optional-dependencies]
 test = ["pytest", "coverage"]


### PR DESCRIPTION
Since it is imported in `src/adios4dolfinx/utils.py`