### PR TITLE
Replace `adios2.adios2.ADIOS` with `adios2.ADIOS`

### DIFF
--- a/src/adios4dolfinx/adios2_helpers.py
+++ b/src/adios4dolfinx/adios2_helpers.py
@@ -22,7 +22,7 @@ adios_to_numpy_dtype = {"float": np.float32, "double": np.float64,
 
 
 def read_cell_perms(
-    adios: adios2.adios2.ADIOS,
+    adios: adios2.ADIOS,
     comm: MPI.Intracomm,
     filename: pathlib.Path,
     variable: str,
@@ -85,7 +85,7 @@ def read_cell_perms(
 
 
 def read_dofmap(
-    adios: adios2.adios2.ADIOS,
+    adios: adios2.ADIOS,
     comm: MPI.Intracomm,
     filename: pathlib.Path,
     dofmap: str,
@@ -165,7 +165,7 @@ def read_dofmap(
 
 
 def read_array(
-    adios: adios2.adios2.ADIOS,
+    adios: adios2.ADIOS,
     filename: pathlib.Path, array_name: str, engine: str, comm: MPI.Intracomm
 ) -> Tuple[npt.NDArray[valid_function_types], int]:
     """


### PR DESCRIPTION
I am trying to use this with `adios2` (newly) packaged by @drew-parsons for debian.

The `adios2/__init__.py` file contains the following when `adios2` from `dolfinx/dolfinx`, i.e. built from source:
```
# cat /usr/local/lib/adios2/__init__.py
from .adios2 import *

__version__ = "2.9.1"
```

The `adios2/__init__.py` file contains the following when installed from debian
```
# avoid running mpi with serial (1 process) jobs
# by checking whether mpi is actually being used over multiple processes
# Probe number of processes with OMPI_COMM_WORLD_SIZE (openmpi) and MPI_LOCALNRANKS (mpich)

from os import getenv as os_getenv
from sys import modules as sys_modules
from importlib import import_module

_OPENMPI_MULTIPROC = os_getenv('OMPI_COMM_WORLD_SIZE') is not None
_MPICH_MULTIPROC = os_getenv('MPI_LOCALNRANKS') is not None
_MPI_USE_ALWAYS = os_getenv('ADIOS2_ALWAYS_USE_MPI') is not None

_MPI_ACTIVE = _OPENMPI_MULTIPROC or _MPICH_MULTIPROC or _MPI_USE_ALWAYS

if _MPI_ACTIVE:
    try:
        from . import adios2_mpi as _adios2
    except:
        from . import adios2_serial as _adios2
else:
    from . import adios2_serial as _adios2

__version__ = _adios2.__version__

# make generic adios2 module behaviour the same as specific builds
# by importing public and weak internal symbols (single _underscore)
api = [ k for k in _adios2.__dict__.keys() if not k.startswith('__') and not k.endswith('__') ]
this_module=sys_modules[__name__]
for key in api:
    # "imports" symbols (makes them accessible)
    setattr(this_module,key,getattr(_adios2,key))
    # rename symbols as properties of toplevel adios2 module
    sys_modules['adios2.{}'.format(key)] = getattr(_adios2,key)
del api
del this_module

del os_getenv, sys_modules, import_module
```
(notice how the internal `adios2` module is imported as `_adios2`)

While arguably Drew may have to fix the import in the package itself, I think it's fine to use `adios2.ADIOS` instead of `adios2.adios2.ADIOS`, especially considering that every other usage of `adios2.*` I can see in the library does not repeat `adios2` twice.