### PR TITLE
Set "Test package" workflow to actually run on push on every branch, as the comment in the `yml` file says

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -4,7 +4,7 @@ on:
   push:
     # The CI is executed on every push on every branch
     branches:
-      - main
+      - "**"
   pull_request:
     # The CI is executed on every pull request to the main branch
     branches:


### PR DESCRIPTION
I couldn't get workflows to start on the CI on fork. Half of the reason was that I forgot that GitHub Actions must be manually enabled on forks, but I guess that the other half of the reason was that `.github/workflows/test_package.yml` was only running on `main`.