### PR TITLE
Bump actions/{configure-pages,deploy-pages} to v4

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -54,8 +54,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This is ready to be merged, but I am marking it as draft until you test

https://github.com/jorgensd/adios4dolfinx/compare/main...francesco-ballarin:adios4dolfinx:artifact2-tmp

The difference between this branch `artifact2` (that should be merged) and `artifact2-tmp` is that the latter contains an extra commit (that should not be merged) to test the github pages workflow. I can't run that on my fork because I don't have github pages set up there.