### PR TITLE
Consistent name for argument `filename`

### DIFF
--- a/src/adios4dolfinx/adios2_helpers.py
+++ b/src/adios4dolfinx/adios2_helpers.py
@@ -1,6 +1,6 @@
-import pathlib
+from pathlib import Path
 from typing import Tuple
-
+from typing import Union
 from mpi4py import MPI
 
 import dolfinx.cpp.graph
@@ -33,7 +33,7 @@ adios_to_numpy_dtype = {"float": np.float32, "double": np.float64,
 def read_cell_perms(
     adios: adios2.ADIOS,
     comm: MPI.Intracomm,
-    filename: pathlib.Path,
+    filename: Union[Path, str],
     variable: str,
     num_cells_global: np.int64,
     engine: str,
@@ -96,7 +96,7 @@ def read_cell_perms(
 def read_dofmap(
     adios: adios2.ADIOS,
     comm: MPI.Intracomm,
-    filename: pathlib.Path,
+    filename: Union[Path, str],
     dofmap: str,
     dofmap_offsets: str,
     num_cells_global: np.int64,
@@ -175,7 +175,7 @@ def read_dofmap(
 
 def read_array(
         adios: adios2.ADIOS,
-        filename: pathlib.Path, array_name: str, engine: str, comm: MPI.Intracomm,
+        filename: Union[Path, str], array_name: str, engine: str, comm: MPI.Intracomm,
         time: float = 0., time_name: str = "",
         legacy: bool = False) -> Tuple[npt.NDArray[valid_function_types], int]:
     """


### PR DESCRIPTION
Be consistent about using 'filename' rather than 'file' and fix corresponding type hints.

Most functions use the argument name `filename` for the path to the file, but a few functions use `file`. Changing these to be consistent. Also using `Union[Path, str]` as the type hint for filename (some places where only `str`, others had only `Path`)