### PR TITLE
Use tmp-dir and tmp_path to store test files.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61.0.0", "wheel"]
 [project]
 name = "adios4dolfinx"
 version = "0.8.0.dev0"
-description = "Wrappers for reading/writing DOLFINx meshes/functions with ADIOS2"
+description = "Checkkpointing functionality for DOLFINx meshes/functions with ADIOS2"
 authors = [{ name = "Jørgen S. Dokken", email = "dokken@simula.no" }]
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61.0.0", "wheel"]
 [project]
 name = "adios4dolfinx"
 version = "0.8.0.dev0"
-description = "Checkkpointing functionality for DOLFINx meshes/functions with ADIOS2"
+description = "Checkpointing functionality for DOLFINx meshes/functions with ADIOS2"
 authors = [{ name = "Jørgen S. Dokken", email = "dokken@simula.no" }]
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import pathlib
-
 from mpi4py import MPI
 
 import dolfinx
@@ -20,7 +18,7 @@ def cluster():
 
 
 @pytest.fixture(scope="function")
-def write_function():
+def write_function(tmp_path):
     def _write_function(mesh, el, f, dtype, name="uh", append: bool = False) -> str:
         V = dolfinx.fem.functionspace(mesh, el)
         uh = dolfinx.fem.Function(V, dtype=dtype)
@@ -37,7 +35,7 @@ def write_function():
         )
 
         file_hash = f"{el_hash}_{np.dtype(dtype).name}"
-        filename = pathlib.Path(f"output/mesh_{file_hash}.bp")
+        filename = tmp_path / f"mesh_{file_hash}.bp"
         if mesh.comm.size != 1:
             if not append:
                 adios4dolfinx.write_mesh(filename, mesh)
@@ -54,9 +52,9 @@ def write_function():
 
 
 @pytest.fixture(scope="function")
-def read_function():
+def read_function(tmp_path):
     def _read_function(comm, el, f, hash, dtype, name="uh"):
-        filename = f"output/mesh_{hash}.bp"
+        filename = tmp_path / f"mesh_{hash}.bp"
         engine = "BP4"
         mesh = adios4dolfinx.read_mesh(filename, comm, engine, dolfinx.mesh.GhostMode.shared_facet)
         V = dolfinx.fem.functionspace(mesh, el)
@@ -94,7 +92,7 @@ def get_dtype():
 
 
 @pytest.fixture(scope="function")
-def write_function_time_dep():
+def write_function_time_dep(tmp_path):
     def _write_function_time_dep(mesh, el, f0, f1, t0, t1, dtype) -> str:
         V = dolfinx.fem.functionspace(mesh, el)
         uh = dolfinx.fem.Function(V, dtype=dtype)
@@ -109,7 +107,7 @@ def write_function_time_dep():
             .replace("]", "")
         )
         file_hash = f"{el_hash}_{np.dtype(dtype).name}"
-        filename = pathlib.Path(f"output/mesh_{file_hash}.bp")
+        filename = tmp_path / f"mesh_{file_hash}.bp"
         if mesh.comm.size != 1:
             adios4dolfinx.write_mesh(filename, mesh)
             adios4dolfinx.write_function(filename, uh, time=t0)
@@ -129,9 +127,9 @@ def write_function_time_dep():
 
 
 @pytest.fixture(scope="function")
-def read_function_time_dep():
+def read_function_time_dep(tmp_path):
     def _read_function_time_dep(comm, el, f0, f1, t0, t1, hash, dtype):
-        filename = f"output/mesh_{hash}.bp"
+        filename = tmp_path / f"mesh_{hash}.bp"
         engine = "BP4"
         mesh = adios4dolfinx.read_mesh(filename, comm, engine, dolfinx.mesh.GhostMode.shared_facet)
         V = dolfinx.fem.functionspace(mesh, el)

--- a/tests/test_checkpointing_vector.py
+++ b/tests/test_checkpointing_vector.py
@@ -67,9 +67,9 @@ def test_read_write_2D(
             values[1] += 2j * x[0]
         return values
 
-    hash = write_function(mesh, el, f, f_dtype)
+    fname = write_function(mesh, el, f, f_dtype)
     MPI.COMM_WORLD.Barrier()
-    read_function(read_comm, el, f, hash, f_dtype)
+    read_function(read_comm, el, f, fname, f_dtype)
 
 
 @pytest.mark.parametrize("is_complex", [True, False])
@@ -93,9 +93,9 @@ def test_read_write_3D(
             values[1] += 2j * np.cos(x[2])
         return values
 
-    hash = write_function(mesh, el, f, dtype=f_dtype)
+    fname = write_function(mesh, el, f, dtype=f_dtype)
     MPI.COMM_WORLD.Barrier()
-    read_function(read_comm, el, f, hash, dtype=f_dtype)
+    read_function(read_comm, el, f, fname, dtype=f_dtype)
 
 
 @pytest.mark.parametrize("is_complex", [True, False])

--- a/tests/test_mesh_writer.py
+++ b/tests/test_mesh_writer.py
@@ -1,4 +1,3 @@
-import pathlib
 import time
 
 from mpi4py import MPI
@@ -14,10 +13,10 @@ from adios4dolfinx import read_mesh, write_mesh
 @pytest.mark.parametrize("encoder, suffix", [("BP4", ".bp"), ("HDF5", ".h5")])
 # , ("BP5", ".bp")]) # Deactivated, see: https://github.com/jorgensd/adios4dolfinx/issues/7
 @pytest.mark.parametrize("ghost_mode", [dolfinx.mesh.GhostMode.shared_facet])
-def test_mesh_read_writer(encoder, suffix, ghost_mode):
+def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
     N = 25
-    file = pathlib.Path(f"output/adios_mesh_{encoder}")
-    xdmf_file = pathlib.Path("output/xdmf_mesh")
+    file = tmp_path / f"adios_mesh_{encoder}"
+    xdmf_file = tmp_path / "xdmf_mesh"
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, N, N, N, ghost_mode=ghost_mode)
 
     start = time.perf_counter()

--- a/tests/test_mesh_writer.py
+++ b/tests/test_mesh_writer.py
@@ -15,8 +15,10 @@ from adios4dolfinx import read_mesh, write_mesh
 @pytest.mark.parametrize("ghost_mode", [dolfinx.mesh.GhostMode.shared_facet])
 def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
     N = 25
-    file = tmp_path / f"adios_mesh_{encoder}"
-    xdmf_file = tmp_path / "xdmf_mesh"
+    # Consistent tmp dir across processes
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    file = fname / f"adios_mesh_{encoder}"
+    xdmf_file = fname / "xdmf_mesh"
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, N, N, N, ghost_mode=ghost_mode)
 
     start = time.perf_counter()

--- a/tests/test_meshtags.py
+++ b/tests/test_meshtags.py
@@ -100,7 +100,8 @@ def test_checkpointing_meshtags_1D(mesh_1D, read_comm, read_mode, tmp_path):
 
     # Write unique mesh file for each combination of MPI communicator and dtype
     hash = f"{mesh.comm.size}_{mesh.geometry.x.dtype}"
-    filename = tmp_path / f"meshtags_1D_{hash}.bp"
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    filename = fname / f"meshtags_1D_{hash}.bp"
 
     # If mesh communicator is more than a self communicator or serial write on all processes.
     # If serial or self communicator, only write on root rank
@@ -170,7 +171,8 @@ def test_checkpointing_meshtags_1D(mesh_1D, read_comm, read_mode, tmp_path):
 def test_checkpointing_meshtags_2D(mesh_2D, read_comm, read_mode, tmp_path):
     mesh = mesh_2D
     hash = f"{mesh.comm.size}_{mesh.topology.cell_name()}_{mesh.geometry.x.dtype}"
-    filename = tmp_path / f"meshtags_1D_{hash}.bp"
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    filename = fname / f"meshtags_1D_{hash}.bp"
     if mesh.comm.size != 1:
         adios4dolfinx.write_mesh(filename, mesh, engine="BP4")
     else:
@@ -224,7 +226,8 @@ def test_checkpointing_meshtags_2D(mesh_2D, read_comm, read_mode, tmp_path):
 def test_checkpointing_meshtags_3D(mesh_3D, read_comm, read_mode, tmp_path):
     mesh = mesh_3D
     hash = f"{mesh.comm.size}_{mesh.topology.cell_name()}_{mesh.geometry.x.dtype}"
-    filename = tmp_path / f"meshtags_1D_{hash}.bp"
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    filename = fname / f"meshtags_1D_{hash}.bp"
     if mesh.comm.size != 1:
         adios4dolfinx.write_mesh(filename, mesh, engine="BP4")
     else:

--- a/tests/test_meshtags.py
+++ b/tests/test_meshtags.py
@@ -95,12 +95,12 @@ def generate_reference_map(
 
 @pytest.mark.parametrize("read_mode", read_modes)
 @pytest.mark.parametrize("read_comm", [MPI.COMM_SELF, MPI.COMM_WORLD])
-def test_checkpointing_meshtags_1D(mesh_1D, read_comm, read_mode):
+def test_checkpointing_meshtags_1D(mesh_1D, read_comm, read_mode, tmp_path):
     mesh = mesh_1D
 
     # Write unique mesh file for each combination of MPI communicator and dtype
     hash = f"{mesh.comm.size}_{mesh.geometry.x.dtype}"
-    filename = f"meshtags_1D_{hash}.bp"
+    filename = tmp_path / f"meshtags_1D_{hash}.bp"
 
     # If mesh communicator is more than a self communicator or serial write on all processes.
     # If serial or self communicator, only write on root rank
@@ -167,10 +167,10 @@ def test_checkpointing_meshtags_1D(mesh_1D, read_comm, read_mode):
 
 @pytest.mark.parametrize("read_mode", read_modes)
 @pytest.mark.parametrize("read_comm", [MPI.COMM_SELF, MPI.COMM_WORLD])
-def test_checkpointing_meshtags_2D(mesh_2D, read_comm, read_mode):
+def test_checkpointing_meshtags_2D(mesh_2D, read_comm, read_mode, tmp_path):
     mesh = mesh_2D
     hash = f"{mesh.comm.size}_{mesh.topology.cell_name()}_{mesh.geometry.x.dtype}"
-    filename = f"meshtags_1D_{hash}.bp"
+    filename = tmp_path / f"meshtags_1D_{hash}.bp"
     if mesh.comm.size != 1:
         adios4dolfinx.write_mesh(filename, mesh, engine="BP4")
     else:
@@ -221,10 +221,10 @@ def test_checkpointing_meshtags_2D(mesh_2D, read_comm, read_mode):
 
 @pytest.mark.parametrize("read_mode", read_modes)
 @pytest.mark.parametrize("read_comm", [MPI.COMM_SELF, MPI.COMM_WORLD])
-def test_checkpointing_meshtags_3D(mesh_3D, read_comm, read_mode):
+def test_checkpointing_meshtags_3D(mesh_3D, read_comm, read_mode, tmp_path):
     mesh = mesh_3D
     hash = f"{mesh.comm.size}_{mesh.topology.cell_name()}_{mesh.geometry.x.dtype}"
-    filename = f"meshtags_1D_{hash}.bp"
+    filename = tmp_path / f"meshtags_1D_{hash}.bp"
     if mesh.comm.size != 1:
         adios4dolfinx.write_mesh(filename, mesh, engine="BP4")
     else:

--- a/tests/test_original_checkpoint.py
+++ b/tests/test_original_checkpoint.py
@@ -39,6 +39,7 @@ def create_simplex_mesh_2D(tmp_path_factory):
         dtype=np.float64,
     )
     fname = tmp_path_factory.mktemp("output") / "original_mesh_2D_simplex.xdmf"
+    fname = MPI.COMM_WORLD.bcast(fname, root=0)
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "w") as xdmf:
         xdmf.write_mesh(mesh)
     return fname

--- a/tests/test_original_checkpoint.py
+++ b/tests/test_original_checkpoint.py
@@ -30,7 +30,7 @@ three_dim_combinations = itertools.product(dtypes, three_dimensional_cell_types)
 
 
 @pytest.fixture(scope="module")
-def create_simplex_mesh_2D():
+def create_simplex_mesh_2D(tmp_path_factory):
     mesh = dolfinx.mesh.create_unit_square(
         MPI.COMM_WORLD,
         10,
@@ -38,14 +38,14 @@ def create_simplex_mesh_2D():
         cell_type=dolfinx.mesh.CellType.triangle,
         dtype=np.float64,
     )
-    fname = Path("output/original_mesh_2D_simplex.xdmf")
+    fname = tmp_path_factory.mktemp("output") / "original_mesh_2D_simplex.xdmf"
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "w") as xdmf:
         xdmf.write_mesh(mesh)
     return fname
 
 
 @pytest.fixture(scope="module")
-def create_simplex_mesh_3D():
+def create_simplex_mesh_3D(tmp_path_factory):
     mesh = dolfinx.mesh.create_unit_cube(
         MPI.COMM_WORLD,
         5,
@@ -54,14 +54,14 @@ def create_simplex_mesh_3D():
         cell_type=dolfinx.mesh.CellType.tetrahedron,
         dtype=np.float64,
     )
-    fname = Path("output/original_mesh_3D_simplex.xdmf")
+    fname = tmp_path_factory.mktemp("output") / "original_mesh_3D_simplex.xdmf"
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "w") as xdmf:
         xdmf.write_mesh(mesh)
     return fname
 
 
 @pytest.fixture(scope="module")
-def create_non_simplex_mesh_2D():
+def create_non_simplex_mesh_2D(tmp_path_factory):
     mesh = dolfinx.mesh.create_unit_square(
         MPI.COMM_WORLD,
         10,
@@ -69,14 +69,14 @@ def create_non_simplex_mesh_2D():
         cell_type=dolfinx.mesh.CellType.quadrilateral,
         dtype=np.float64,
     )
-    fname = Path("output/original_mesh_2D_non_simplex.xdmf")
+    fname = tmp_path_factory.mktemp("output") / "original_mesh_2D_non_simplex.xdmf"
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "w") as xdmf:
         xdmf.write_mesh(mesh)
     return fname
 
 
 @pytest.fixture(scope="module")
-def create_non_simplex_mesh_3D():
+def create_non_simplex_mesh_3D(tmp_path_factory):
     mesh = dolfinx.mesh.create_unit_cube(
         MPI.COMM_WORLD,
         5,
@@ -85,27 +85,27 @@ def create_non_simplex_mesh_3D():
         cell_type=dolfinx.mesh.CellType.hexahedron,
         dtype=np.float64,
     )
-    fname = Path("output/original_mesh_3D_non_simplex.xdmf")
+    fname = tmp_path_factory.mktemp("output") / "original_mesh_3D_non_simplex.xdmf"
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "w") as xdmf:
         xdmf.write_mesh(mesh)
     return fname
 
 
 @pytest.fixture(params=two_dim_combinations, scope="module")
-def create_2D_mesh(request):
+def create_2D_mesh(request, tmpdir_factory):
     dtype, cell_type = request.param
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 5, 7, cell_type=cell_type, dtype=dtype)
-    fname = Path("output/original_mesh_2D_{dtype}_{cell_type}.xdmf")
+    fname = Path(tmpdir_factory.mktemp("output")) / f"original_mesh_2D_{dtype}_{cell_type}.xdmf"
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "w") as xdmf:
         xdmf.write_mesh(mesh)
     return fname
 
 
 @pytest.fixture(params=three_dim_combinations, scope="module")
-def create_3D_mesh(request):
+def create_3D_mesh(request, tmpdir_factory):
     dtype, cell_type = request.param
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 5, 7, 3, cell_type=cell_type, dtype=dtype)
-    fname = Path("output/original_mesh_3D_{dtype}_{cell_type}.xdmf")
+    fname = Path(tmpdir_factory.mktemp("output")) / f"original_mesh_3D_{dtype}_{cell_type}.xdmf"
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "w") as xdmf:
         xdmf.write_mesh(mesh)
     return fname
@@ -118,6 +118,7 @@ def write_function_original(
     f: Callable[[np.ndarray], np.ndarray],
     dtype: np.dtype,
     name: str,
+    path: Path,
 ) -> Path:
     """Convenience function for writing function to file on the original input mesh"""
     V = dolfinx.fem.functionspace(mesh, el)
@@ -135,8 +136,7 @@ def write_function_original(
     )
 
     file_hash = f"{el_hash}_{np.dtype(dtype).name}"
-    filename = Path(f"output/mesh_{file_hash}.bp")
-
+    filename = path / f"mesh_{file_hash}.bp"
     if write_mesh:
         adios4dolfinx.write_mesh_input_order(filename, mesh)
     adios4dolfinx.write_function_on_input_mesh(filename, uh, time=0.0)
@@ -198,6 +198,7 @@ def write_function_vector(
     f: Callable[[np.ndarray], np.ndarray],
     dtype: np.dtype,
     name: str,
+    dir: Path,
 ) -> Path:
     """Convenience function for writing function to file on the original input mesh"""
     from mpi4py import MPI
@@ -226,7 +227,7 @@ def write_function_vector(
     )
 
     file_hash = f"{el_hash}_{np.dtype(dtype).name}"
-    filename = Path(f"output/mesh_{file_hash}.bp")
+    filename = dir / f"mesh_{file_hash}.bp"
 
     if write_mesh:
         adios4dolfinx.write_mesh_input_order(filename, mesh)
@@ -274,7 +275,7 @@ def read_function_vector(
 @pytest.mark.parametrize("degree", [1, 4])
 @pytest.mark.parametrize("write_mesh", [True, False])
 def test_read_write_P_2D(
-    write_mesh, family, degree, is_complex, create_2D_mesh, cluster, get_dtype
+    write_mesh, family, degree, is_complex, create_2D_mesh, cluster, get_dtype, tmp_path
 ):
     fname = create_2D_mesh
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "r") as xdmf:
@@ -299,13 +300,12 @@ def test_read_write_P_2D(
             values[1] += 2j * x[0]
         return values
 
-    hash = write_function_original(write_mesh, mesh, el, f, f_dtype, "u_original")
+    hash = write_function_original(write_mesh, mesh, el, f, f_dtype, "u_original", tmp_path)
 
     if write_mesh:
-        mesh_fname = fname
-    else:
         mesh_fname = hash
-
+    else:
+        mesh_fname = fname
     query = cluster[:].apply_async(
         read_function_original, mesh_fname, hash, "u_original", family, degree, f, f_dtype
     )
@@ -319,7 +319,7 @@ def test_read_write_P_2D(
 @pytest.mark.parametrize("degree", [1, 4])
 @pytest.mark.parametrize("write_mesh", [True, False])
 def test_read_write_P_3D(
-    write_mesh, family, degree, is_complex, create_3D_mesh, cluster, get_dtype
+    write_mesh, family, degree, is_complex, create_3D_mesh, cluster, get_dtype, tmp_path
 ):
     fname = create_3D_mesh
     with dolfinx.io.XDMFFile(MPI.COMM_WORLD, fname, "r") as xdmf:
@@ -344,13 +344,13 @@ def test_read_write_P_3D(
             values[2] += 2j
         return values
 
-    hash = write_function_original(write_mesh, mesh, el, f, f_dtype, "u_original")
+    hash = write_function_original(write_mesh, mesh, el, f, f_dtype, "u_original", tmp_path)
     MPI.COMM_WORLD.Barrier()
 
     if write_mesh:
-        mesh_fname = fname
-    else:
         mesh_fname = hash
+    else:
+        mesh_fname = fname
 
     query = cluster[:].apply_async(
         read_function_original, mesh_fname, hash, "u_original", family, degree, f, f_dtype
@@ -365,7 +365,7 @@ def test_read_write_P_3D(
 @pytest.mark.parametrize("family", ["N1curl", "RT"])
 @pytest.mark.parametrize("degree", [1, 4])
 def test_read_write_2D_vector_simplex(
-    write_mesh, family, degree, is_complex, create_simplex_mesh_2D, cluster, get_dtype
+    write_mesh, family, degree, is_complex, create_simplex_mesh_2D, cluster, get_dtype, tmp_path
 ):
     fname = create_simplex_mesh_2D
 
@@ -381,14 +381,7 @@ def test_read_write_2D_vector_simplex(
         return values
 
     query = cluster[:].apply_async(
-        write_function_vector,
-        write_mesh,
-        fname,
-        family,
-        degree,
-        f,
-        f_dtype,
-        "u_original",
+        write_function_vector, write_mesh, fname, family, degree, f, f_dtype, "u_original", tmp_path
     )
     query.wait()
     assert query.successful(), query.error
@@ -409,7 +402,7 @@ def test_read_write_2D_vector_simplex(
 @pytest.mark.parametrize("family", ["N1curl", "RT"])
 @pytest.mark.parametrize("degree", [1, 4])
 def test_read_write_3D_vector_simplex(
-    write_mesh, family, degree, is_complex, create_simplex_mesh_3D, cluster, get_dtype
+    write_mesh, family, degree, is_complex, create_simplex_mesh_3D, cluster, get_dtype, tmp_path
 ):
     fname = create_simplex_mesh_3D
 
@@ -426,14 +419,7 @@ def test_read_write_3D_vector_simplex(
         return values
 
     query = cluster[:].apply_async(
-        write_function_vector,
-        write_mesh,
-        fname,
-        family,
-        degree,
-        f,
-        f_dtype,
-        "u_original",
+        write_function_vector, write_mesh, fname, family, degree, f, f_dtype, "u_original", tmp_path
     )
     query.wait()
     assert query.successful(), query.error
@@ -454,7 +440,7 @@ def test_read_write_3D_vector_simplex(
 @pytest.mark.parametrize("family", ["RTCF"])
 @pytest.mark.parametrize("degree", [1, 2, 3])
 def test_read_write_2D_vector_non_simplex(
-    write_mesh, family, degree, is_complex, create_non_simplex_mesh_2D, cluster, get_dtype
+    write_mesh, family, degree, is_complex, create_non_simplex_mesh_2D, cluster, get_dtype, tmp_path
 ):
     fname = create_non_simplex_mesh_2D
 
@@ -470,14 +456,7 @@ def test_read_write_2D_vector_non_simplex(
         return values
 
     query = cluster[:].apply_async(
-        write_function_vector,
-        write_mesh,
-        fname,
-        family,
-        degree,
-        f,
-        f_dtype,
-        "u_original",
+        write_function_vector, write_mesh, fname, family, degree, f, f_dtype, "u_original", tmp_path
     )
     query.wait()
     assert query.successful(), query.error
@@ -498,7 +477,7 @@ def test_read_write_2D_vector_non_simplex(
 @pytest.mark.parametrize("family", ["NCF"])
 @pytest.mark.parametrize("degree", [1, 4])
 def test_read_write_3D_vector_non_simplex(
-    write_mesh, family, degree, is_complex, create_non_simplex_mesh_3D, cluster, get_dtype
+    write_mesh, family, degree, is_complex, create_non_simplex_mesh_3D, cluster, get_dtype, tmp_path
 ):
     fname = create_non_simplex_mesh_3D
 
@@ -514,14 +493,7 @@ def test_read_write_3D_vector_non_simplex(
         return values
 
     query = cluster[:].apply_async(
-        write_function_vector,
-        write_mesh,
-        fname,
-        family,
-        degree,
-        f,
-        f_dtype,
-        "u_original",
+        write_function_vector, write_mesh, fname, family, degree, f, f_dtype, "u_original", tmp_path
     )
     query.wait()
     assert query.successful(), query.error

--- a/tests/test_snapshot_checkpoint.py
+++ b/tests/test_snapshot_checkpoint.py
@@ -24,7 +24,7 @@ hex = dolfinx.mesh.CellType.hexahedron
     "cell_type, family", [(triangle, "N1curl"), (triangle, "RT"), (quad, "RTCF")]
 )
 @pytest.mark.parametrize("degree", [1, 4])
-def test_read_write_2D(family, degree, cell_type):
+def test_read_write_2D(family, degree, cell_type, tmp_path):
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 10, 10, cell_type=cell_type)
     el = basix.ufl.element(family, mesh.ufl_cell().cellname(), degree)
 
@@ -35,7 +35,8 @@ def test_read_write_2D(family, degree, cell_type):
     u = dolfinx.fem.Function(V)
     u.interpolate(f)
 
-    file = Path("snapshot_2D_vs.bp")
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    file = fname / Path("snapshot_2D_vs.bp")
     snapshot_checkpoint(u, file, adios2.Mode.Write)
 
     v = dolfinx.fem.Function(V)
@@ -45,7 +46,7 @@ def test_read_write_2D(family, degree, cell_type):
 
 @pytest.mark.parametrize("cell_type, family", [(tetra, "N1curl"), (tetra, "RT"), (hex, "NCF")])
 @pytest.mark.parametrize("degree", [1, 4])
-def test_read_write_3D(family, degree, cell_type):
+def test_read_write_3D(family, degree, cell_type, tmp_path):
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 3, 3, 3, cell_type=cell_type)
     el = basix.ufl.element(family, mesh.ufl_cell().cellname(), degree)
 
@@ -56,7 +57,8 @@ def test_read_write_3D(family, degree, cell_type):
     u = dolfinx.fem.Function(V)
     u.interpolate(f)
 
-    file = Path("snapshot_3D_vs.bp")
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    file = fname / Path("snapshot_3D_vs.bp")
     snapshot_checkpoint(u, file, adios2.Mode.Write)
 
     v = dolfinx.fem.Function(V)
@@ -69,7 +71,7 @@ def test_read_write_3D(family, degree, cell_type):
 )
 @pytest.mark.parametrize("family", ["Lagrange", "DG"])
 @pytest.mark.parametrize("degree", [1, 4])
-def test_read_write_P_2D(family, degree, cell_type):
+def test_read_write_P_2D(family, degree, cell_type, tmp_path):
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 5, 5, cell_type=cell_type)
     el = basix.ufl.element(family, mesh.ufl_cell().cellname(), degree, shape=(mesh.geometry.dim,))
 
@@ -80,7 +82,8 @@ def test_read_write_P_2D(family, degree, cell_type):
     u = dolfinx.fem.Function(V)
     u.interpolate(f)
 
-    file = Path("snapshot_2D_p.bp")
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    file = fname / Path("snapshot_2D_p.bp")
     snapshot_checkpoint(u, file, adios2.Mode.Write)
 
     v = dolfinx.fem.Function(V)
@@ -93,7 +96,7 @@ def test_read_write_P_2D(family, degree, cell_type):
 )
 @pytest.mark.parametrize("family", ["Lagrange", "DG"])
 @pytest.mark.parametrize("degree", [1, 4])
-def test_read_write_P_3D(family, degree, cell_type):
+def test_read_write_P_3D(family, degree, cell_type, tmp_path):
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 5, 5, 5, cell_type=cell_type)
     el = basix.ufl.element(family, mesh.ufl_cell().cellname(), degree, shape=(mesh.geometry.dim,))
 
@@ -104,7 +107,8 @@ def test_read_write_P_3D(family, degree, cell_type):
     u = dolfinx.fem.Function(V)
     u.interpolate(f)
 
-    file = Path("snapshot_3D_p.bp")
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    file = fname / Path("snapshot_3D_p.bp")
     snapshot_checkpoint(u, file, adios2.Mode.Write)
 
     v = dolfinx.fem.Function(V)


### PR DESCRIPTION
Makes it way easier to parse the large amount of test output files.

A bit fiddly to get to work with MPI (each rank gets its own tmp path/dir). Broadcasting from rank 0 to make consistent.