### PR TITLE
Make it possible to read and write attributes

### DIFF
--- a/src/adios4dolfinx/__init__.py
+++ b/src/adios4dolfinx/__init__.py
@@ -8,9 +8,11 @@
 from importlib.metadata import metadata
 
 from .checkpointing import (
+    read_attributes,
     read_function,
     read_mesh,
     read_meshtags,
+    write_attributes,
     write_function,
     write_mesh,
     write_meshtags,
@@ -38,4 +40,6 @@ __all__ = [
     "snapshot_checkpoint",
     "write_function_on_input_mesh",
     "write_mesh_input_order",
+    "write_attributes",
+    "read_attributes",
 ]

--- a/src/adios4dolfinx/checkpointing.py
+++ b/src/adios4dolfinx/checkpointing.py
@@ -43,6 +43,7 @@ __all__ = [
     "write_mesh",
     "read_meshtags",
     "write_meshtags",
+    "read_attributes",
     "write_attributes",
 ]
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -10,17 +10,29 @@ import adios4dolfinx
 
 @pytest.mark.parametrize("comm", [MPI.COMM_SELF, MPI.COMM_WORLD])
 def test_read_write_attributes(comm, tmp_path):
-    attributes = {
+    attributes1 = {
         "a": np.array([1, 2, 3], dtype=np.uint8),
-        "b": np.array([4, 5, 6], dtype=np.uint8),
+        "b": np.array([4, 5], dtype=np.uint8),
+    }
+    attributes2 = {
+        "c": np.array([6], dtype=np.uint8),
+        "d": np.array([7, 8, 9, 10], dtype=np.uint8),
     }
     fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
     file = fname / Path("attributes.bp")
 
-    adios4dolfinx.write_attributes(comm=comm, filename=file, name="test", attributes=attributes)
+    adios4dolfinx.write_attributes(comm=comm, filename=file, name="group1", attributes=attributes1)
+    adios4dolfinx.write_attributes(comm=comm, filename=file, name="group2", attributes=attributes2)
     MPI.COMM_WORLD.Barrier()
-    loaded_attributes = adios4dolfinx.read_attributes(comm=comm, filename=file, name="test")
-    for k, v in loaded_attributes.items():
-        assert np.allclose(v, attributes[k])
-    for k, v in attributes.items():
-        assert np.allclose(v, loaded_attributes[k])
+    loaded_attributes1 = adios4dolfinx.read_attributes(comm=comm, filename=file, name="group1")
+    loaded_attributes2 = adios4dolfinx.read_attributes(comm=comm, filename=file, name="group2")
+
+    for k, v in loaded_attributes1.items():
+        assert np.allclose(v, attributes1[k])
+    for k, v in attributes1.items():
+        assert np.allclose(v, loaded_attributes1[k])
+
+    for k, v in loaded_attributes2.items():
+        assert np.allclose(v, attributes2[k])
+    for k, v in attributes2.items():
+        assert np.allclose(v, loaded_attributes2[k])

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from mpi4py import MPI
+
+import numpy as np
+import pytest
+
+import adios4dolfinx
+
+
+@pytest.mark.parametrize("comm", [MPI.COMM_SELF, MPI.COMM_WORLD])
+def test_read_write_attributes(comm, tmp_path):
+    attributes = {
+        "a": np.array([1, 2, 3], dtype=np.uint8),
+        "b": np.array([4, 5, 6], dtype=np.uint8),
+    }
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    file = fname / Path("attributes.bp")
+
+    adios4dolfinx.write_attributes(comm=comm, filename=file, name="test", attributes=attributes)
+    MPI.COMM_WORLD.Barrier()
+    loaded_attributes = adios4dolfinx.read_attributes(comm=comm, filename=file, name="test")
+    for k, v in loaded_attributes.items():
+        assert np.allclose(v, attributes[k])
+    for k, v in attributes.items():
+        assert np.allclose(v, loaded_attributes[k])


### PR DESCRIPTION
Sometimes it might be relevant to write additional attributes to file. 

In my specific case I want to save a mesh with the mesh tags as well as a dictionary of tags, for example
```python
attributes = {"facets_1": [value1, dim - 1], "facets_2": [value2, dim - 1], "cells_1": [value3, dim]}
```
Here we just make it possible to add save dictionaries with strings as keys and values being numpy arrays. 
Note that I also make it possible to pass a name so that we can group attributes together e.g
```python
adios4dolfinx.write_attributes(comm=comm, filename=file, name="group1", attributes=attributes1)
adios4dolfinx.write_attributes(comm=comm, filename=file, name="group2", attributes=attributes2)
```