### PR TITLE
Add read from partition

### DIFF
--- a/src/adios4dolfinx/adios2_helpers.py
+++ b/src/adios4dolfinx/adios2_helpers.py
@@ -131,7 +131,7 @@ def read_dofmap(
     dofmap_offsets: str,
     num_cells_global: np.int64,
     engine: str,
-) -> dolfinx.cpp.graph.AdjacencyList_int64:
+) -> dolfinx.cpp.graph.AdjacencyList_int64 | dolfinx.cpp.graph.AdjacencyList_int32:
     """
     Read dofmap with given communicator,
     split in continuous chunks based on number of cells in the mesh (global).
@@ -195,8 +195,6 @@ def read_dofmap(
         cell_dofs.SetSelection([[in_offsets[0]], [in_offsets[-1] - in_offsets[0]]])
         in_dofmap = np.empty(in_offsets[-1] - in_offsets[0], dtype=cell_dofs.Type().strip("_t"))
         adios_file.file.Get(cell_dofs, in_dofmap, adios2.Mode.Sync)
-
-        in_dofmap = in_dofmap.astype(np.int64)
         in_offsets -= in_offsets[0]
 
         adios_file.file.EndStep()

--- a/src/adios4dolfinx/original_checkpoint.py
+++ b/src/adios4dolfinx/original_checkpoint.py
@@ -176,6 +176,9 @@ def create_original_mesh_data(mesh: dolfinx.mesh.Mesh) -> MeshData:
     geometry = geometry[:, :gdim].copy()
     assert local_node_range[1] - local_node_range[0] == geometry.shape[0]
     cmap = mesh.geometry.cmap
+
+    # NOTE: Could in theory store partitioning information, but would not work nicely
+    # as one would need to read this data rather than the xdmffile.
     return MeshData(
         local_geometry=geometry,
         local_geometry_pos=local_node_range,
@@ -186,6 +189,12 @@ def create_original_mesh_data(mesh: dolfinx.mesh.Mesh) -> MeshData:
         cell_type=mesh.topology.cell_name(),
         degree=cmap.degree,
         lagrange_variant=cmap.variant,
+        store_partition=False,
+        partition_processes=None,
+        ownership_array=None,
+        ownership_offset=None,
+        partition_range=None,
+        partition_global=None,
     )
 
 

--- a/src/adios4dolfinx/structures.py
+++ b/src/adios4dolfinx/structures.py
@@ -31,6 +31,14 @@ class MeshData:
     degree: int
     lagrange_variant: int
 
+    # Partitioning_information
+    store_partition: bool
+    partition_processes: int | None  # Number of processes in partition
+    ownership_array: npt.NDArray[np.int32] | None  # Ownership array for cells
+    ownership_offset: npt.NDArray[np.int32] | None  # Ownership offset for cells
+    partition_range: tuple[int, int] | None  # Local insert position for partitioning information
+    partition_global: int | None
+
 
 @dataclass
 class FunctionData:

--- a/src/adios4dolfinx/writers.py
+++ b/src/adios4dolfinx/writers.py
@@ -76,6 +76,33 @@ def write_mesh(
         )
 
         adios_file.file.Put(dvar, mesh.local_topology)
+
+        # Add partitioning data
+        if mesh.store_partition:
+            par_data = adios_file.io.DefineVariable(
+                "PartitioningData",
+                mesh.ownership_array,
+                shape=[mesh.partition_global],
+                start=[mesh.partition_range[0]],
+                count=[
+                    mesh.partition_range[1] - mesh.partition_range[0],
+                ],
+            )
+            adios_file.file.Put(par_data, mesh.ownership_array)
+
+            par_offset = adios_file.io.DefineVariable(
+                "PartitioningOffset",
+                mesh.ownership_offset,
+                shape=[mesh.num_cells_global + 1],
+                start=[mesh.local_topology_pos[0]],
+                count=[mesh.local_topology_pos[1] - mesh.local_topology_pos[0] + 1],
+            )
+            adios_file.file.Put(par_offset, mesh.ownership_offset)
+
+            adios_file.io.DefineAttribute(
+                "PartitionProcesses", np.array([mesh.partition_processes], dtype=np.int32)
+            )
+
         adios_file.file.PerformPuts()
         adios_file.file.EndStep()
 

--- a/tests/test_mesh_writer.py
+++ b/tests/test_mesh_writer.py
@@ -10,11 +10,13 @@ import ufl
 from adios4dolfinx import read_mesh, write_mesh
 
 
-@pytest.mark.parametrize("encoder, suffix", [("BP4", ".bp"), ("HDF5", ".h5")])
-# , ("BP5", ".bp")]) # Deactivated, see: https://github.com/jorgensd/adios4dolfinx/issues/7
-@pytest.mark.parametrize("ghost_mode", [dolfinx.mesh.GhostMode.shared_facet])
-def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
-    N = 25
+@pytest.mark.parametrize("encoder, suffix", [("BP4", ".bp"), ("HDF5", ".h5"), ("BP5", ".bp")])
+@pytest.mark.parametrize(
+    "ghost_mode", [dolfinx.mesh.GhostMode.shared_facet, dolfinx.mesh.GhostMode.none]
+)
+@pytest.mark.parametrize("store_partition", [True, False])
+def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path, store_partition):
+    N = 3
     # Consistent tmp dir across processes
     fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
     file = fname / f"adios_mesh_{encoder}"
@@ -22,7 +24,7 @@ def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, N, N, N, ghost_mode=ghost_mode)
 
     start = time.perf_counter()
-    write_mesh(file.with_suffix(suffix), mesh, encoder)
+    write_mesh(file.with_suffix(suffix), mesh, encoder, store_partition_info=store_partition)
     end = time.perf_counter()
     print(f"Write ADIOS2 mesh: {end-start}")
 
@@ -35,7 +37,45 @@ def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
     mesh.comm.Barrier()
 
     start = time.perf_counter()
-    mesh_adios = read_mesh(file.with_suffix(suffix), MPI.COMM_WORLD, encoder, ghost_mode)
+    mesh_adios = read_mesh(
+        file.with_suffix(suffix), MPI.COMM_WORLD, encoder, ghost_mode, store_partition
+    )
+
+    if store_partition:
+
+        def compute_distance_matrix(points_A, points_B, tol=1e-12):
+            points_A_e = np.expand_dims(points_A, 1)
+            points_B_e = np.expand_dims(points_B, 0)
+            distances = np.sum(np.square(points_A_e - points_B_e), axis=2)
+            return distances < tol
+
+        cell_map = mesh.topology.index_map(mesh.topology.dim)
+        new_cell_map = mesh_adios.topology.index_map(mesh_adios.topology.dim)
+        assert cell_map.size_local == new_cell_map.size_local
+        assert cell_map.num_ghosts == new_cell_map.num_ghosts
+        midpoints = dolfinx.mesh.compute_midpoints(
+            mesh,
+            mesh.topology.dim,
+            np.arange(cell_map.size_local + cell_map.num_ghosts, dtype=np.int32),
+        )
+        new_midpoints = dolfinx.mesh.compute_midpoints(
+            mesh_adios,
+            mesh_adios.topology.dim,
+            np.arange(new_cell_map.size_local + new_cell_map.num_ghosts, dtype=np.int32),
+        )
+        # Check that all points in owned by initial mesh is owned by the new mesh
+        # (might be locally reordered)
+        owned_distances = compute_distance_matrix(
+            midpoints[: cell_map.size_local], new_midpoints[: new_cell_map.size_local]
+        )
+        np.testing.assert_allclose(np.sum(owned_distances, axis=1), 1)
+        # Check that all points that are ghosted in original mesh is ghosted on the
+        # same process in the new mesh
+        ghost_distances = compute_distance_matrix(
+            midpoints[cell_map.size_local :], new_midpoints[new_cell_map.size_local :]
+        )
+        np.testing.assert_allclose(np.sum(ghost_distances, axis=1), 1)
+
     end = time.perf_counter()
     print(f"Read ADIOS2 mesh: {end-start}")
     mesh.comm.Barrier()
@@ -56,7 +96,10 @@ def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
         )
 
     # Check that integration over different entities are consistent
-    for measure in [ufl.ds, ufl.dS, ufl.dx]:
+    measures = (
+        [ufl.ds, ufl.dx] if ghost_mode is dolfinx.mesh.GhostMode.none else [ufl.ds, ufl.dS, ufl.dx]
+    )
+    for measure in measures:
         c_adios = dolfinx.fem.assemble_scalar(dolfinx.fem.form(1 * measure(domain=mesh_adios)))
         c_ref = dolfinx.fem.assemble_scalar(dolfinx.fem.form(1 * measure(domain=mesh)))
         c_xdmf = dolfinx.fem.assemble_scalar(dolfinx.fem.form(1 * measure(domain=mesh_xdmf)))


### PR DESCRIPTION
Addresses Add read in partitioning option for adios4dolfinx #27.

One can with this PR read partitioning data from the adios4dolfinx file to re-use partitioning (including ghosted cells) from a previous run.

The local order of the cells can be re-ordered.
