### PR TITLE
Add time dependent mesh checkpoint

### DIFF
--- a/src/adios4dolfinx/checkpointing.py
+++ b/src/adios4dolfinx/checkpointing.py
@@ -545,6 +545,7 @@ def read_mesh(
         partition_graph = read_adjacency_list(
             adios, comm, filename, "PartitioningData", "PartitioningOffset", shape[0], engine
         )
+
         def partitioner(comm: MPI.Intracomm, n, m, topo):
             assert len(partition_graph.offsets) - 1 == topo.num_nodes
             return partition_graph
@@ -603,7 +604,7 @@ def write_mesh(
         if cell_offsets[-1] == 0:
             cell_array = np.empty(0, dtype=np.int32)
         else:
-            cell_array = cell_map.array[:cell_offsets[-1]]
+            cell_array = cell_map.array[: cell_offsets[-1]]
 
         # Compute adjacency with current process as first entry
         ownership_array = np.full(num_cells_local + cell_offsets[-1], -1, dtype=np.int32)

--- a/src/adios4dolfinx/checkpointing.py
+++ b/src/adios4dolfinx/checkpointing.py
@@ -562,7 +562,7 @@ def write_mesh(
     engine: str = "BP4",
     mode: adios2.Mode = adios2.Mode.Write,
     time: float = 0.0,
-    store_partition_info: bool = False
+    store_partition_info: bool = False,
 ):
     """
     Write a mesh to specified ADIOS2 format, see:

--- a/src/adios4dolfinx/writers.py
+++ b/src/adios4dolfinx/writers.py
@@ -5,13 +5,13 @@
 # SPDX-License-Identifier:    MIT
 
 
+import warnings
 from pathlib import Path
 
 from mpi4py import MPI
 
 import adios2
 import numpy as np
-import warnings
 
 from .adios2_helpers import ADIOSFile, resolve_adios_scope
 from .structures import FunctionData, MeshData

--- a/src/adios4dolfinx/writers.py
+++ b/src/adios4dolfinx/writers.py
@@ -55,29 +55,25 @@ def write_mesh(
         )
         adios_file.file.Put(pointvar, mesh.local_geometry, adios2.Mode.Sync)
 
-        # Write celltype
-        adios_file.io.DefineAttribute("CellType", mesh.cell_type)
-
-        # Write basix properties
-        adios_file.io.DefineAttribute("Degree", np.array([mesh.degree], dtype=np.int32))
-        adios_file.io.DefineAttribute(
-            "LagrangeVariant", np.array([mesh.lagrange_variant], dtype=np.int32)
-        )
-
-        # Write topology
-        num_dofs_per_cell = mesh.local_topology.shape[1]
-        dvar = adios_file.io.DefineVariable(
-            "Topology",
-            mesh.local_topology,
-            shape=[mesh.num_cells_global, num_dofs_per_cell],
-            start=[mesh.local_topology_pos[0], 0],
-            count=[
-                mesh.local_topology_pos[1] - mesh.local_topology_pos[0],
-                num_dofs_per_cell,
-            ],
-        )
-
-        adios_file.file.Put(dvar, mesh.local_topology)
+        if mode == adios2.Mode.Write:
+            adios_file.io.DefineAttribute("CellType", mesh.cell_type)
+            adios_file.io.DefineAttribute("Degree", np.array([mesh.degree], dtype=np.int32))
+            adios_file.io.DefineAttribute(
+                "LagrangeVariant", np.array([mesh.lagrange_variant], dtype=np.int32)
+            )
+            # Write topology (on;y on first write as topology is constant)
+            num_dofs_per_cell = mesh.local_topology.shape[1]
+            dvar = adios_file.io.DefineVariable(
+                "Topology",
+                mesh.local_topology,
+                shape=[mesh.num_cells_global, num_dofs_per_cell],
+                start=[mesh.local_topology_pos[0], 0],
+                count=[
+                    mesh.local_topology_pos[1] - mesh.local_topology_pos[0],
+                    num_dofs_per_cell,
+                ],
+            )
+            adios_file.file.Put(dvar, mesh.local_topology)
 
         # Add time step to file
         t_arr = np.array([time], dtype=np.float64)

--- a/tests/test_legacy_readers.py
+++ b/tests/test_legacy_readers.py
@@ -149,7 +149,7 @@ def test_adios4dolfinx_legacy():
         pytest.skip(f"{path} does not exist")
 
     el = ("N1curl", 3)
-    mesh = read_mesh(path, comm, "BP4", dolfinx.mesh.GhostMode.shared_facet)
+    mesh = read_mesh(path, comm, "BP4", dolfinx.mesh.GhostMode.shared_facet, legacy=True)
 
     def f(x):
         values = np.zeros((2, x.shape[1]), dtype=np.float64)

--- a/tests/test_mesh_writer.py
+++ b/tests/test_mesh_writer.py
@@ -1,4 +1,3 @@
-
 from mpi4py import MPI
 
 import dolfinx
@@ -72,7 +71,7 @@ def test_timedep_mesh(encoder, suffix, ghost_mode, tmp_path):
     def u(x):
         return np.asarray([x[0] + 0.1 * np.sin(x[1]), 0.2 * np.cos(x[1]), x[2]])
 
-    write_mesh(file.with_suffix(suffix), mesh, encoder)
+    write_mesh(file.with_suffix(suffix), mesh, encoder, mode=adios2.Mode.Write, time=0.0)
     delta_x = u(mesh.geometry.x.T).T
     mesh.geometry.x[:] += delta_x
     write_mesh(file.with_suffix(suffix), mesh, encoder, mode=adios2.Mode.Append, time=3.0)

--- a/tests/test_mesh_writer.py
+++ b/tests/test_mesh_writer.py
@@ -28,10 +28,13 @@ def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path, store_partition
         xdmf.write_mesh(mesh)
     mesh.comm.Barrier()
 
-
-    mesh_adios = read_mesh(file.with_suffix(suffix), MPI.COMM_WORLD, engine=encoder,
-                           ghost_mode=ghost_mode,
-                           read_from_partition=store_partition)
+    mesh_adios = read_mesh(
+        file.with_suffix(suffix),
+        MPI.COMM_WORLD,
+        engine=encoder,
+        ghost_mode=ghost_mode,
+        read_from_partition=store_partition,
+    )
     mesh_adios.comm.Barrier()
     if store_partition:
 
@@ -116,13 +119,27 @@ def test_timedep_mesh(encoder, suffix, ghost_mode, tmp_path, store_partition):
     def u(x):
         return np.asarray([x[0] + 0.1 * np.sin(x[1]), 0.2 * np.cos(x[1]), x[2]])
 
-    write_mesh(file.with_suffix(suffix), mesh, encoder, mode=adios2.Mode.Write, time=0.0, store_partition_info=store_partition)
+    write_mesh(
+        file.with_suffix(suffix),
+        mesh,
+        encoder,
+        mode=adios2.Mode.Write,
+        time=0.0,
+        store_partition_info=store_partition,
+    )
     delta_x = u(mesh.geometry.x.T).T
     mesh.geometry.x[:] += delta_x
     write_mesh(file.with_suffix(suffix), mesh, encoder, mode=adios2.Mode.Append, time=3.0)
     mesh.geometry.x[:] -= delta_x
 
-    mesh_first = read_mesh(file.with_suffix(suffix), MPI.COMM_WORLD, encoder, ghost_mode, time=0.0, read_from_partition=store_partition)
+    mesh_first = read_mesh(
+        file.with_suffix(suffix),
+        MPI.COMM_WORLD,
+        encoder,
+        ghost_mode,
+        time=0.0,
+        read_from_partition=store_partition,
+    )
     mesh_first.comm.Barrier()
 
     # Check that integration over different entities are consistent
@@ -138,7 +155,14 @@ def test_timedep_mesh(encoder, suffix, ghost_mode, tmp_path, store_partition):
         )
 
     mesh.geometry.x[:] += delta_x
-    mesh_second = read_mesh(file.with_suffix(suffix), MPI.COMM_WORLD, encoder, ghost_mode, time=3.0, read_from_partition=store_partition)
+    mesh_second = read_mesh(
+        file.with_suffix(suffix),
+        MPI.COMM_WORLD,
+        encoder,
+        ghost_mode,
+        time=3.0,
+        read_from_partition=store_partition,
+    )
     mesh_second.comm.Barrier()
     measures = [ufl.ds, ufl.dx]
     if ghost_mode == dolfinx.mesh.GhostMode.shared_facet:

--- a/tests/test_mesh_writer.py
+++ b/tests/test_mesh_writer.py
@@ -1,4 +1,3 @@
-import time
 
 from mpi4py import MPI
 
@@ -8,6 +7,7 @@ import pytest
 import ufl
 
 from adios4dolfinx import read_mesh, write_mesh
+from adios4dolfinx.adios2_helpers import adios2
 
 
 @pytest.mark.parametrize("encoder, suffix", [("BP4", ".bp"), ("HDF5", ".h5")])
@@ -21,30 +21,17 @@ def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
     xdmf_file = fname / "xdmf_mesh"
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, N, N, N, ghost_mode=ghost_mode)
 
-    start = time.perf_counter()
     write_mesh(file.with_suffix(suffix), mesh, encoder)
-    end = time.perf_counter()
-    print(f"Write ADIOS2 mesh: {end-start}")
-
     mesh.comm.Barrier()
-    start = time.perf_counter()
     with dolfinx.io.XDMFFile(mesh.comm, xdmf_file.with_suffix(".xdmf"), "w") as xdmf:
         xdmf.write_mesh(mesh)
-    end = time.perf_counter()
-    print(f"Write XDMF mesh: {end-start}")
     mesh.comm.Barrier()
 
-    start = time.perf_counter()
     mesh_adios = read_mesh(file.with_suffix(suffix), MPI.COMM_WORLD, encoder, ghost_mode)
-    end = time.perf_counter()
-    print(f"Read ADIOS2 mesh: {end-start}")
-    mesh.comm.Barrier()
+    mesh_adios.comm.Barrier()
 
-    start = time.perf_counter()
     with dolfinx.io.XDMFFile(mesh.comm, xdmf_file.with_suffix(".xdmf"), "r") as xdmf:
         mesh_xdmf = xdmf.read_mesh(ghost_mode=ghost_mode)
-    end = time.perf_counter()
-    print(f"Read XDMF mesh: {end-start}")
 
     for i in range(mesh.topology.dim + 1):
         mesh.topology.create_entities(i)
@@ -66,5 +53,56 @@ def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path):
         )
         assert np.isclose(
             mesh_adios.comm.allreduce(c_adios, MPI.SUM),
+            mesh.comm.allreduce(c_ref, MPI.SUM),
+        )
+
+
+@pytest.mark.parametrize("encoder, suffix", [("BP4", ".bp"), ("BP5", ".bp")])
+@pytest.mark.parametrize(
+    "ghost_mode", [dolfinx.mesh.GhostMode.shared_facet, dolfinx.mesh.GhostMode.none]
+)
+def test_timedep_mesh(encoder, suffix, ghost_mode, tmp_path):
+    # Currently unsupported, unclear why ("HDF5", ".h5"),
+    N = 25
+    # Consistent tmp dir across processes
+    fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    file = fname / f"adios_time_dep_mesh_{encoder}"
+    mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, N, N, N, ghost_mode=ghost_mode)
+
+    def u(x):
+        return np.asarray([x[0] + 0.1 * np.sin(x[1]), 0.2 * np.cos(x[1]), x[2]])
+
+    write_mesh(file.with_suffix(suffix), mesh, encoder)
+    delta_x = u(mesh.geometry.x.T).T
+    mesh.geometry.x[:] += delta_x
+    write_mesh(file.with_suffix(suffix), mesh, encoder, mode=adios2.Mode.Append, time=3.0)
+    mesh.geometry.x[:] -= delta_x
+
+    mesh_first = read_mesh(file.with_suffix(suffix), MPI.COMM_WORLD, encoder, ghost_mode, time=0.0)
+    mesh_first.comm.Barrier()
+
+    # Check that integration over different entities are consistent
+    measures = [ufl.ds, ufl.dx]
+    if ghost_mode == dolfinx.mesh.GhostMode.shared_facet:
+        measures.append(ufl.dx)
+    for measure in measures:
+        c_adios = dolfinx.fem.assemble_scalar(dolfinx.fem.form(1 * measure(domain=mesh_first)))
+        c_ref = dolfinx.fem.assemble_scalar(dolfinx.fem.form(1 * measure(domain=mesh)))
+        assert np.isclose(
+            mesh_first.comm.allreduce(c_adios, MPI.SUM),
+            mesh.comm.allreduce(c_ref, MPI.SUM),
+        )
+
+    mesh.geometry.x[:] += delta_x
+    mesh_second = read_mesh(file.with_suffix(suffix), MPI.COMM_WORLD, encoder, ghost_mode, time=3.0)
+    mesh_second.comm.Barrier()
+    measures = [ufl.ds, ufl.dx]
+    if ghost_mode == dolfinx.mesh.GhostMode.shared_facet:
+        measures.append(ufl.dx)
+    for measure in measures:
+        c_adios = dolfinx.fem.assemble_scalar(dolfinx.fem.form(1 * measure(domain=mesh_second)))
+        c_ref = dolfinx.fem.assemble_scalar(dolfinx.fem.form(1 * measure(domain=mesh)))
+        assert np.isclose(
+            mesh_second.comm.allreduce(c_adios, MPI.SUM),
             mesh.comm.allreduce(c_ref, MPI.SUM),
         )

--- a/tests/test_mesh_writer.py
+++ b/tests/test_mesh_writer.py
@@ -15,11 +15,11 @@ from adios4dolfinx.adios2_helpers import adios2
 )
 @pytest.mark.parametrize("store_partition", [True, False])
 def test_mesh_read_writer(encoder, suffix, ghost_mode, tmp_path, store_partition):
-    N = 5
+    N = 7
     # Consistent tmp dir across processes
     fname = MPI.COMM_WORLD.bcast(tmp_path, root=0)
-    file = fname / f"adios_mesh_{encoder}"
-    xdmf_file = fname / "xdmf_mesh"
+    file = fname / f"adios_mesh_{encoder}_{store_partition}"
+    xdmf_file = fname / "xdmf_mesh_{encode}_{ghost_mode}_{store_partition}"
     mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, N, N, N, ghost_mode=ghost_mode)
 
     write_mesh(file.with_suffix(suffix), mesh, encoder, store_partition_info=store_partition)


### PR DESCRIPTION
Write mesh to file with associated time stamp.

Only time dependent mesh variable is the geometry.
Topology and cell information is assumed to be written at the first step in the file.

Resolves #71.

**Other fixes**
Fixes a bug in partitioning that happened if ran on more than two processes.