### PR TITLE
Increase MPICH runners to 4 processes

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -17,7 +17,6 @@ on:
     - cron: "0 8 * * *"
 
 jobs:
-
   create-datasets:
     uses: ./.github/workflows/create_legacy_data.yml
     with:
@@ -27,7 +26,7 @@ jobs:
     uses: ./.github/workflows/create_legacy_checkpoint.yml
     with:
       artifact_name: "legacy_checkpoint_mpich"
-  
+
   check-formatting:
     uses: ./.github/workflows/check_formatting.yml
 
@@ -49,13 +48,13 @@ jobs:
         with:
           name: legacy_mpich
           path: ./legacy
-    
+
       - name: Download legacy data
         uses: actions/download-artifact@v4
         with:
           name: legacy_checkpoint_mpich
           path: ./legacy_checkpoint
-    
+
       - name: Install package
         run: python3 -m pip install .[test]
 
@@ -65,7 +64,7 @@ jobs:
 
       - name: Run tests in parallel
         run: |
-          mpirun -n 2 coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/
+          mpirun -n 4 coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/
 
       - name: Combine coverage reports
         run: |

--- a/.github/workflows/test_package_openmpi.yml
+++ b/.github/workflows/test_package_openmpi.yml
@@ -36,6 +36,7 @@ jobs:
       PETSC_ARCH: "linux-gnu-real64-32"
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
     strategy:
       matrix:
@@ -74,4 +75,4 @@ jobs:
 
       - name: Run tests in parallel
         run: |
-          mpirun -n 4 --map-by :OVERSUBSCRIBE coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/
+          mpirun -n 4 coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/

--- a/.github/workflows/test_package_openmpi.yml
+++ b/.github/workflows/test_package_openmpi.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           adios2: ${{ matrix.adios2 }}
           petsc_arch: ${{ env.PETSC_ARCH }}
-          dolfinx:  main
+          dolfinx: main
 
       - name: Download legacy data
         uses: actions/download-artifact@v4
@@ -74,4 +74,4 @@ jobs:
 
       - name: Run tests in parallel
         run: |
-          mpirun -n 2 coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/
+          mpirun -n 4 coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/

--- a/.github/workflows/test_package_openmpi.yml
+++ b/.github/workflows/test_package_openmpi.yml
@@ -74,4 +74,4 @@ jobs:
 
       - name: Run tests in parallel
         run: |
-          mpirun -n 4 coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/
+          mpirun -n 4 --map-by :OVERSUBSCRIBE coverage run --rcfile=.coveragerc -m mpi4py -m pytest -xvs ./tests/


### PR DESCRIPTION
As the limit for Github public runners are 4 processes now, testing on more doesn't hurt