### PR TITLE
Expand adios2 build matrix on openmpi to ensure we are testing 2.9.2 and 2.10.0

### DIFF
--- a/.github/workflows/test_package_openmpi.yml
+++ b/.github/workflows/test_package_openmpi.yml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        adios2: ["default", "v2.10.0"]
+        adios2: ["default", "v2.9.2", "v2.10.0"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0.0", "wheel"]
 
 [project]
 name = "adios4dolfinx"
-version = "0.8.1"
+version = "0.8.1.post0"
 description = "Checkpointing functionality for DOLFINx meshes/functions with ADIOS2"
 authors = [{ name = "Jørgen S. Dokken", email = "dokken@simula.no" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
As test-env current now uses 2.10.0 by default

Bump adios4dolfinx to post release