### PR TITLE
adios2<2.10 Python bindings are a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Checkpointing functionality for DOLFINx meshes/functions with ADI
 authors = [{ name = "Jørgen S. Dokken", email = "dokken@simula.no" }]
 license = { file = "LICENSE" }
 readme = "README.md"
-dependencies = ["fenics-dolfinx>=0.8.0"]
+dependencies = ["fenics-dolfinx>=0.8.0", "adios2<2.10"]
 
 [project.optional-dependencies]
 test = ["pytest", "coverage", "ipyparallel"]


### PR DESCRIPTION
adios4dolfinx interacts directly with adios2's Python bindings, and only works with the <2.10 API.