### PR TITLE
Fix order of arguments in create_mesh and `LinearProblem` (petsc_options_prefix)

### DIFF
--- a/.github/workflows/test_redhat.yml
+++ b/.github/workflows/test_redhat.yml
@@ -1,17 +1,17 @@
 name: Test package with redhat
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - main
 
   workflow_call:
   workflow_dispatch:
-  schedule:
-    - cron: "0 8 * * *"
+  # schedule:
+  #   - cron: "0 8 * * *"
 
 jobs:
   create-datasets:

--- a/src/adios4dolfinx/checkpointing.py
+++ b/src/adios4dolfinx/checkpointing.py
@@ -649,7 +649,10 @@ def read_mesh_data(
     else:
         partitioner = dolfinx.cpp.mesh.create_cell_partitioner(ghost_mode)
 
-    return mesh_topology, mesh_geometry, domain, partitioner
+    if Version(dolfinx.__version__) > Version("0.9.0"):
+        return mesh_topology, domain, mesh_geometry, partitioner
+    else:
+        return mesh_topology, mesh_geometry, domain, partitioner
 
 
 def read_mesh(
@@ -677,6 +680,7 @@ def read_mesh(
         The distributed mesh
     """
     check_file_exists(filename)
+
     return dolfinx.mesh.create_mesh(
         comm,
         *read_mesh_data(

--- a/src/adios4dolfinx/checkpointing.py
+++ b/src/adios4dolfinx/checkpointing.py
@@ -512,6 +512,17 @@ def read_function(
     u.x.scatter_forward()
 
 
+class ReadMeshData(typing.TypedDict):
+    cells: npt.NDArray[np.int64]
+    e: typing.Union[
+        ufl.Mesh,
+        basix.finite_element.FiniteElement,
+        basix.ufl._BasixElement,
+    ]
+    x: npt.NDArray[np.floating]
+    partitioner: typing.Optional[typing.Callable]
+
+
 def read_mesh_data(
     filename: typing.Union[Path, str],
     comm: MPI.Intracomm,
@@ -520,7 +531,7 @@ def read_mesh_data(
     time: float = 0.0,
     legacy: bool = False,
     read_from_partition: bool = False,
-) -> tuple[np.ndarray, np.ndarray, ufl.Mesh, typing.Callable]:
+) -> ReadMeshData:
     """
     Read an ADIOS2 mesh data for use with DOLFINx.
 
@@ -649,10 +660,12 @@ def read_mesh_data(
     else:
         partitioner = dolfinx.cpp.mesh.create_cell_partitioner(ghost_mode)
 
-    if Version(dolfinx.__version__) > Version("0.9.0"):
-        return mesh_topology, domain, mesh_geometry, partitioner
-    else:
-        return mesh_topology, mesh_geometry, domain, partitioner
+    return ReadMeshData(
+        cells=mesh_topology,
+        x=mesh_geometry,
+        e=domain,
+        partitioner=partitioner,
+    )
 
 
 def read_mesh(
@@ -680,10 +693,9 @@ def read_mesh(
         The distributed mesh
     """
     check_file_exists(filename)
-
     return dolfinx.mesh.create_mesh(
         comm,
-        *read_mesh_data(
+        **read_mesh_data(
             filename,
             comm,
             engine=engine,

--- a/src/adios4dolfinx/legacy_readers.py
+++ b/src/adios4dolfinx/legacy_readers.py
@@ -17,6 +17,7 @@ import dolfinx
 import numpy as np
 import numpy.typing as npt
 import ufl
+from packaging.version import Version
 
 from .adios2_helpers import (
     ADIOSFile,
@@ -322,7 +323,10 @@ def read_mesh_from_legacy_h5(
         shape=(mesh_geometry.shape[1],),
     )
     domain = ufl.Mesh(element)
-    return dolfinx.mesh.create_mesh(MPI.COMM_WORLD, mesh_topology, mesh_geometry, domain)
+
+    return dolfinx.mesh.create_mesh(
+        comm=MPI.COMM_WORLD, cells=mesh_topology, x=mesh_geometry, e=domain
+    )
 
 
 def read_function_from_legacy_h5(

--- a/src/adios4dolfinx/legacy_readers.py
+++ b/src/adios4dolfinx/legacy_readers.py
@@ -17,7 +17,6 @@ import dolfinx
 import numpy as np
 import numpy.typing as npt
 import ufl
-from packaging.version import Version
 
 from .adios2_helpers import (
     ADIOSFile,

--- a/tests/test_legacy_readers.py
+++ b/tests/test_legacy_readers.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier:    MIT
 
 
+import inspect
 import pathlib
 
 from mpi4py import MPI
@@ -84,7 +85,13 @@ def test_legacy_function():
     L = ufl.inner(f, v) * ufl.dx
 
     uh = dolfinx.fem.Function(V)
-    problem = LinearProblem(a, L, [], uh, petsc_options={"ksp_type": "preonly", "pc_type": "lu"})
+    if "petsc_options_prefix" in inspect.signature(LinearProblem.__init__).parameters.keys():
+        extra_options = {"petsc_options_prefix": "legacy_test"}
+    else:
+        extra_options = {}
+    problem = LinearProblem(
+        a, L, bcs=[], u=uh, petsc_options={"ksp_type": "preonly", "pc_type": "lu"}, **extra_options
+    )
     problem.solve()
 
     u_in = dolfinx.fem.Function(V)
@@ -117,7 +124,13 @@ def test_read_legacy_function_from_checkpoint():
     L = ufl.inner(f, v) * ufl.dx
 
     uh = dolfinx.fem.Function(V)
-    problem = LinearProblem(a, L, [], uh, petsc_options={"ksp_type": "preonly", "pc_type": "lu"})
+    if "petsc_options_prefix" in inspect.signature(LinearProblem.__init__).parameters.keys():
+        extra_options = {"petsc_options_prefix": "legacy_checkpoint_test"}
+    else:
+        extra_options = {}
+    problem = LinearProblem(
+        a, L, bcs=[], u=uh, petsc_options={"ksp_type": "preonly", "pc_type": "lu"}, **extra_options
+    )
     problem.solve()
 
     u_in = dolfinx.fem.Function(V)


### PR DESCRIPTION
- API for `create_mesh` has been changed in https://github.com/FEniCS/dolfinx/pull/3826
- API for `LinearProblem` (relevant for tests) has been changed in: https://github.com/FEniCS/dolfinx/pull/3785
- Deactivate redhat CI (ref #161)