### PR TITLE
Revise CI logic

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -2,9 +2,9 @@ name: Github Pages
 
 on:
   push:
-    branches: [release]
+    branches: [main]
   pull_request:
-    branches: [release]
+    branches: [main]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `adios4dolfinx` library extends the [DOLFINx](https://github.com/FEniCS/dolf
 
 Compatibility with DOLFINx:
 
-- ADIOS4DOLFINx v0.9.0 is compatible with DOLFINx v0.9.x
+- ADIOS4DOLFINx v0.9.4 is compatible with DOLFINx v0.9.x
 - ADIOS4DOLFINx v0.8.1 is compatible with DOLFINx v0.8.x
 - ADIOS4DOLFINx v0.7.3 is compatible with DOLFINx v0.7.x
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0.0", "wheel"]
 
 [project]
 name = "adios4dolfinx"
-version = "0.9.3"
+version = "0.9.4"
 description = "Checkpointing functionality for DOLFINx meshes/functions with ADIOS2"
 authors = [{ name = "Jørgen S. Dokken", email = "dokken@simula.no" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
Since we now support backwards compatibility on main, a release branch is no longer necessary.

Let webpage test against release, while we check tests against main on PR.