### PR TITLE
Update docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ sphinx:
         - jupytext.reads
         - fmt: py
 
+    autodoc_typehints: signature
+    autodoc_typehints_format: short
     codeautolink_concat_default: True
     intersphinx_mapping:
       basix: ["https://docs.fenicsproject.org/basix/main/python", null]
@@ -55,5 +57,8 @@ sphinx:
       packaging: ["https://packaging.pypa.io/en/stable/", null]
       matplotlib: ["https://matplotlib.org/stable/", null]
       ipyparallel: ["https://ipyparallel.readthedocs.io/en/stable/", null]
+      python: ["https://docs.python.org/3", null]
+      h5py: ["https://docs.h5py.org/en/stable/", null]
+      adios2: ["https://adios2.readthedocs.io/en/latest", null]
 
 exclude_patterns: [".pytest_cache/*"]

--- a/_toc.yml
+++ b/_toc.yml
@@ -2,6 +2,11 @@ format: jb-book
 root: README
 
 parts:
+  - caption: How to guides
+    chapters:
+    - file: "docs/adding_backend"
+    - file: "docs/migration_guide"
+    
   - caption: Introduction to IPyParallel
     chapters:
     - file: "docs/ipyparallel_intro"

--- a/_toc.yml
+++ b/_toc.yml
@@ -26,3 +26,6 @@ parts:
   - caption: Python API
     chapters:
     - file: "docs/api"
+    - file: "docs/backend"
+    - file: "docs/adios2"
+    - file: "docs/h5py"

--- a/docs/adding_backend.md
+++ b/docs/adding_backend.md
@@ -1,78 +1,81 @@
 # Adding a custom backend
 
-`adios4dolfinx` is designed to be backend-agnostic, meaning you can implement custom readers and writers for different file formats by adhering to a specific protocol.
+{py:mod}`adios4dolfinx` is designed to be backend-agnostic, meaning you can implement custom readers and writers for different file formats by adhering to a specific protocol.
 
 ## The IOBackend Protocol
 
-Any backend must implement the `IOBackend` protocol defined in `src/adios4dolfinx/backends/__init__.py`. This protocol ensures that the backend provides all necessary methods for reading and writing meshes, functions, and attributes.
+Any backend must implement the {py:class}`IOBackend<adios4dolfinx.backends.IOBackend>` protocol defined in {py:mod}`adios4dolfinx.backends`. This protocol ensures that the backend provides all necessary methods for reading and writing meshes, functions, and attributes.
 
-To use a custom backend, you simply pass the python module name (as a string) to the `backend` argument of any `adios4dolfinx` function. The library will attempt to import the module and use it as the backend.
+To use a custom backend, you simply pass the python module name (as a string) to the `backend` argument of any {py:mod}`adios4dolfinx` function.
+The library will attempt to import the module and use it as the backend.
 
 ## Required Data Structures
 
-Your backend will interact with several data classes defined in `src/adios4dolfinx/structures.py`. You should import these to type-hint your implementation correctly:
+Your backend will interact with several data classes defined in {py:mod}`adios4dolfinx.structures`.
+You should import these to type-hint your implementation correctly:
 
-* **`MeshData`**: Contains local geometry, topology, and partitioning information for writing meshes.
-* **`ReadMeshData`**: A container for returning mesh data (cells, geometry, etc.) when reading.
-* **`FunctionData`**: Contains function values, dofmaps, and permutation info for writing functions.
-* **`MeshTagsData`**: Contains indices, values, and metadata for mesh tags.
+* {py:class}`MeshData<adios4dolfinx.structures.MeshData>`: Contains local geometry, topology, and partitioning information for writing {py:class}`meshes<dolfinx.mesh.Mesh>`.
+* {py:class}`ReadMeshData<adios4dolfinx.structures.ReadMeshData>`: A container for returning mesh data (cells, geometry, etc.) when reading.
+* {py:class}`FunctionData<adios4dolfinx.structures.FunctionData>`: Contains function values, dofmaps, and permutation info for writing functions.
+* {py:class}`MeshTagsData<adios4dolfinx.structures.MeshTagsData>`: Contains indices, values, and metadata for mesh tags.
 
 ## Implementation Checklist
 
-Your backend module must implement the functions listed below. Note that `comm` is always an `MPI.Intracomm` and `filename` is a `pathlib.Path` or `str`.
+Your backend module must implement the functions listed below. Note that `comm` is always an {py:class}`MPI.Intracomm<mpi4py.MPI.Intracomm>` and `filename` is a
+{py:class}`pathlib.Path` or {py:class}`str`.
 
 ### General Configuration
 
-* `get_default_backend_args(arguments: dict[str, Any] | None) -> dict[str, Any]`
+* {py:func}`~adios4dolfinx.backends.IOBackend.get_default_backend_args`
     * Returns a dictionary of default arguments (e.g., engine type) for your backend.
 
 ### Attribute IO
 
-* `write_attributes(filename, comm, name, attributes, backend_args)`
+* {py:func}`~adios4dolfinx.backends.IOBackend.write_attributes`
     * Writes a dictionary of attributes (key-value pairs) to the file under the specified `name` (group).
-* `read_attributes(filename, comm, name, backend_args) -> dict`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_attributes`
     * Reads and returns attributes associated with `name`.
 
 ### Mesh IO
 
-* `write_mesh(filename, comm, mesh: MeshData, backend_args, mode, time)`
+* {py:func}`~adios4dolfinx.backends.IOBackend.write_mesh`
     * Writes mesh geometry, topology, and optionally partitioning data.
-    * Must handle `FileMode.write` (new file) and `FileMode.append`.
-* `read_mesh_data(filename, comm, time, read_from_partition, backend_args) -> ReadMeshData`
+    * Must handle {py:class}`FileMode.write` (new file) and {py:class}`FileMode.append`.
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_mesh_data`
     * Reads mesh geometry and topology at a specific `time`.
     * If `read_from_partition` is True, it should read pre-calculated partitioning data to avoid re-partitioning.
 
 ### MeshTags IO
 
-* `write_meshtags(filename, comm, data: MeshTagsData, backend_args)`
+* {py:func}`~adios4dolfinx.backends.IOBackend.write_meshtags`
     * Writes mesh tag indices and values.
-* `read_meshtags_data(filename, comm, name, backend_args) -> MeshTagsData`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_meshtags_data`
     * Reads mesh tags identified by `name`.
 
 ### Function IO
 
-* `write_function(filename, comm, u: FunctionData, time, mode, backend_args)`
+* {py:func}`~adios4dolfinx.backends.IOBackend.write_function`
     * Writes function values, global dofmaps, and cell permutations.
-* `read_dofmap(filename, comm, name, backend_args) -> dolfinx.graph.AdjacencyList`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_dofmap`
     * Reads the dofmap (connectivity) for the function `name`.
-* `read_dofs(filename, comm, name, time, backend_args) -> tuple[np.ndarray, int]`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_dofs`
     * Reads the local chunk of function values for a specific `time`.
     * Returns the array of values and the global starting index of that chunk.
-* `read_cell_perms(comm, filename, backend_args) -> np.ndarray`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_cell_perms`
     * Reads cell permutation data used to map input cells to the current mesh.
-* `read_timestamps(filename, comm, function_name, backend_args) -> np.ndarray`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_timestamps`
     * Returns all available time-steps for a given function.
 
 ### Legacy Support (Optional but defined in protocol)
 
-* `read_legacy_mesh(filename, comm, group) -> tuple`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_legacy_mesh`
     * Reads mesh data from legacy DOLFIN HDF5/XDMF formats.
-* `read_hdf5_array(comm, filename, group, backend_args) -> tuple`
+* {py:func}`~adios4dolfinx.backends.IOBackend.read_hdf5_array`
     * Reads a raw array from an HDF5-like structure (used for legacy vector reading).
 
 ### Snapshots
 
-* `snapshot_checkpoint(filename, mode, u: dolfinx.fem.Function, backend_args)`
+* {py:func}`~adios4dolfinx.backends.IOBackend.snapshot_checkpoint`
     * Handles lightweight N-to-N checkpointing where data is saved exactly as distributed in memory without global reordering.
 
 ## Example Skeleton

--- a/docs/adding_backend.md
+++ b/docs/adding_backend.md
@@ -1,0 +1,98 @@
+# Adding a custom backend
+
+`adios4dolfinx` is designed to be backend-agnostic, meaning you can implement custom readers and writers for different file formats by adhering to a specific protocol.
+
+## The IOBackend Protocol
+
+Any backend must implement the `IOBackend` protocol defined in `src/adios4dolfinx/backends/__init__.py`. This protocol ensures that the backend provides all necessary methods for reading and writing meshes, functions, and attributes.
+
+To use a custom backend, you simply pass the python module name (as a string) to the `backend` argument of any `adios4dolfinx` function. The library will attempt to import the module and use it as the backend.
+
+## Required Data Structures
+
+Your backend will interact with several data classes defined in `src/adios4dolfinx/structures.py`. You should import these to type-hint your implementation correctly:
+
+* **`MeshData`**: Contains local geometry, topology, and partitioning information for writing meshes.
+* **`ReadMeshData`**: A container for returning mesh data (cells, geometry, etc.) when reading.
+* **`FunctionData`**: Contains function values, dofmaps, and permutation info for writing functions.
+* **`MeshTagsData`**: Contains indices, values, and metadata for mesh tags.
+
+## Implementation Checklist
+
+Your backend module must implement the functions listed below. Note that `comm` is always an `MPI.Intracomm` and `filename` is a `pathlib.Path` or `str`.
+
+### General Configuration
+
+* `get_default_backend_args(arguments: dict[str, Any] | None) -> dict[str, Any]`
+    * Returns a dictionary of default arguments (e.g., engine type) for your backend.
+
+### Attribute IO
+
+* `write_attributes(filename, comm, name, attributes, backend_args)`
+    * Writes a dictionary of attributes (key-value pairs) to the file under the specified `name` (group).
+* `read_attributes(filename, comm, name, backend_args) -> dict`
+    * Reads and returns attributes associated with `name`.
+
+### Mesh IO
+
+* `write_mesh(filename, comm, mesh: MeshData, backend_args, mode, time)`
+    * Writes mesh geometry, topology, and optionally partitioning data.
+    * Must handle `FileMode.write` (new file) and `FileMode.append`.
+* `read_mesh_data(filename, comm, time, read_from_partition, backend_args) -> ReadMeshData`
+    * Reads mesh geometry and topology at a specific `time`.
+    * If `read_from_partition` is True, it should read pre-calculated partitioning data to avoid re-partitioning.
+
+### MeshTags IO
+
+* `write_meshtags(filename, comm, data: MeshTagsData, backend_args)`
+    * Writes mesh tag indices and values.
+* `read_meshtags_data(filename, comm, name, backend_args) -> MeshTagsData`
+    * Reads mesh tags identified by `name`.
+
+### Function IO
+
+* `write_function(filename, comm, u: FunctionData, time, mode, backend_args)`
+    * Writes function values, global dofmaps, and cell permutations.
+* `read_dofmap(filename, comm, name, backend_args) -> dolfinx.graph.AdjacencyList`
+    * Reads the dofmap (connectivity) for the function `name`.
+* `read_dofs(filename, comm, name, time, backend_args) -> tuple[np.ndarray, int]`
+    * Reads the local chunk of function values for a specific `time`.
+    * Returns the array of values and the global starting index of that chunk.
+* `read_cell_perms(comm, filename, backend_args) -> np.ndarray`
+    * Reads cell permutation data used to map input cells to the current mesh.
+* `read_timestamps(filename, comm, function_name, backend_args) -> np.ndarray`
+    * Returns all available time-steps for a given function.
+
+### Legacy Support (Optional but defined in protocol)
+
+* `read_legacy_mesh(filename, comm, group) -> tuple`
+    * Reads mesh data from legacy DOLFIN HDF5/XDMF formats.
+* `read_hdf5_array(comm, filename, group, backend_args) -> tuple`
+    * Reads a raw array from an HDF5-like structure (used for legacy vector reading).
+
+### Snapshots
+
+* `snapshot_checkpoint(filename, mode, u: dolfinx.fem.Function, backend_args)`
+    * Handles lightweight N-to-N checkpointing where data is saved exactly as distributed in memory without global reordering.
+
+## Example Skeleton
+
+```python
+from typing import Any
+from pathlib import Path
+from mpi4py import MPI
+import numpy as np
+import dolfinx
+from adios4dolfinx.structures import MeshData, FunctionData, MeshTagsData, ReadMeshData
+from adios4dolfinx.backends import FileMode
+
+def get_default_backend_args(arguments: dict[str, Any] | None) -> dict[str, Any]:
+    return arguments or {}
+
+def write_mesh(filename: Path | str, comm: MPI.Intracomm, mesh: MeshData,
+               backend_args: dict[str, Any] | None, mode: FileMode, time: float):
+    # Implementation here
+    pass
+
+# ... Implement all other methods defined in IOBackend ...
+```

--- a/docs/adios2.rst
+++ b/docs/adios2.rst
@@ -1,0 +1,5 @@
+ADIOS2-backend
+--------------
+
+.. automodule:: adios4dolfinx.backends.adios2.backend
+    :members:

--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -1,0 +1,11 @@
+Backend API
+=============
+
+This module shows what functions and data-classes a new backend should implement to achieve full
+support of all funcntionality.
+
+.. automodule:: adios4dolfinx.backends
+    :members:
+
+.. automodule:: adios4dolfinx.structures
+    :members:

--- a/docs/h5py.rst
+++ b/docs/h5py.rst
@@ -1,0 +1,5 @@
+H5PY-backend
+-------------
+
+.. automodule:: adios4dolfinx.backends.h5py.backend
+    :members:

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -13,19 +13,20 @@ kernelspec:
 # Migration Guide: Transitions to `io4dolfinx`
 
 
-This guide outlines the necessary steps to transition your code from `adios4dolfinx` new API introduced in `io4dolfinx`.
+This guide outlines the necessary steps to transition your code from {py:mod}`adios4dolfinx` new API introduced in `io4dolfinx`.
 
 ## Major Changes
 
 The library has undergone a major refactor to support multiple IO backends.
-**`adios4dolfinx` now supports both [ADIOS2](https://adios2.readthedocs.io/en/latest/) and [h5py](https://docs.h5py.org/en/stable/) backends.**
+**{py:mod}`adios4dolfinx` now supports both [ADIOS2](https://adios2.readthedocs.io/en/latest/) and [h5py](https://docs.h5py.org/en/stable/) backends.**
 
-This allows users to choose between the high-performance, adaptable ADIOS2 framework and the standard HDF5 format via `h5py`, all using the same high-level API. It also opens the door for new backends in the future.
+This allows users to choose between the high-performance, adaptable ADIOS2 framework and the standard HDF5 format via {py:class}`h5py.File`, all using the same high-level API.
+It also opens the door for new backends in the future.
 
 ### Key API Updates
 
-1.  **Backend Agnosticism**: You can now switch between `adios2` (default) and `h5py` by passing a `backend` argument.
-3.  **Engine Configuration**: The explicit `engine` argument (e.g., "BP4", "HDF5") has been removed from function signatures. It is now passed via a dictionary `backend_args`. This is because different backends may have different engine options. For example `adios2` supports "BP4" and "HDF5", while `h5py` does not use engines.
+1.  **Backend Agnosticism**: You can now switch between {py:class}`adios2.ADIOS` (default) and {py:class}`h5py.File` by passing a `backend` argument.
+2.  **Engine Configuration**: The explicit `engine` argument (e.g., "BP4", "HDF5", see ADIOS2 [Engine Types](https://adios2.readthedocs.io/en/latest/engines/engines.html)) has been removed from function signatures. It is now passed via a dictionary `backend_args`. This is because different backends may have different engine options. For example {py:class}`adios2.ADIOS` supports "BP4" and "HDF5", while `h5py` does not use engines.
 
 
 ### Example Transition

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -1,0 +1,83 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Migration Guide: Transitions to `io4dolfinx`
+
+
+This guide outlines the necessary steps to transition your code from `adios4dolfinx` new API introduced in `io4dolfinx`.
+
+## Major Changes
+
+The library has undergone a major refactor to support multiple IO backends.
+**`adios4dolfinx` now supports both [ADIOS2](https://adios2.readthedocs.io/en/latest/) and [h5py](https://docs.h5py.org/en/stable/) backends.**
+
+This allows users to choose between the high-performance, adaptable ADIOS2 framework and the standard HDF5 format via `h5py`, all using the same high-level API. It also opens the door for new backends in the future.
+
+### Key API Updates
+
+1.  **Backend Agnosticism**: You can now switch between `adios2` (default) and `h5py` by passing a `backend` argument.
+3.  **Engine Configuration**: The explicit `engine` argument (e.g., "BP4", "HDF5") has been removed from function signatures. It is now passed via a dictionary `backend_args`. This is because different backends may have different engine options. For example `adios2` supports "BP4" and "HDF5", while `h5py` does not use engines.
+
+
+### Example Transition
+
+#### Writing a Mesh
+
+`````{tab-set}
+````{tab-item} Old API
+```python
+import adios4dolfinx
+adios4dolfinx.write_mesh("mesh.bp", mesh, engine="BP4")
+```
+````
+
+````{tab-item} New API (ADIOS2 Backend)
+```python
+import io4dolfinx
+io4dolfinx.write_mesh("mesh.bp", mesh, backend="adios2", backend_args={"engine": "BP4"})
+```
+````
+
+````{tab-item} New API (h5py Backend)
+```python
+import io4dolfinx
+io4dolfinx.write_mesh("mesh.bp", mesh, backend="h5py")
+```
+````
+
+`````
+
+
+#### Writing a Function
+
+`````{tab-set}
+````{tab-item} Old API
+```python
+import adios4dolfinx
+adios4dolfinx.write_function("solution.bp", u, time=0.0, engine="BP4")
+```
+````
+````{tab-item} New API (ADIOS2 Backend)
+```python
+import io4dolfinx
+io4dolfinx.write_function("solution.bp", u, time=0.0, backend="adios2", backend_args={"engine": "BP4"})
+```
+````
+````{tab-item} New API (h5py Backend)
+```python
+import io4dolfinx
+io4dolfinx.write_function("solution.bp", u, time=0.0, backend="h5py")
+```
+````
+`````
+
+

--- a/docs/partitioned_mesh.py
+++ b/docs/partitioned_mesh.py
@@ -33,7 +33,9 @@ def write_partitioned_mesh(filename: Path):
     )
 
     # Write mesh checkpoint
-    adios4dolfinx.write_mesh(filename, mesh, engine="BP4", store_partition_info=True)
+    adios4dolfinx.write_mesh(
+        filename, mesh, backend="adios2", backend_args={"engine": "BP4"}, store_partition_info=True
+    )
     # Inspect checkpoint on rank 0 with `bpls`
     if mesh.comm.rank == 0:
         output = subprocess.run(["bpls", "-a", "-l", filename], capture_output=True)
@@ -71,7 +73,11 @@ def read_partitioned_mesh(filename: Path, read_from_partition: bool = True):
     prefix = f"{MPI.COMM_WORLD.rank + 1}/{MPI.COMM_WORLD.size}: "
     try:
         mesh = adios4dolfinx.read_mesh(
-            filename, comm=MPI.COMM_WORLD, engine="BP4", read_from_partition=read_from_partition
+            filename,
+            comm=MPI.COMM_WORLD,
+            backend="adios2",
+            backend_args={"engine": "BP4"},
+            read_from_partition=read_from_partition,
         )
         print(f"{prefix} Mesh: {mesh.name} read successfully with {read_from_partition=}")
     except ValueError as e:

--- a/docs/time_dependent_mesh.py
+++ b/docs/time_dependent_mesh.py
@@ -84,10 +84,14 @@ with ipp.Cluster(engines="mpi", n=n, log_level=logging.ERROR) as cluster:
 # The only thing we need to do to read the mesh is to send in the associated time stamp,
 # which we do by adding `time=time_stamp` when calling {py:func}`adios4dolfinx.read_mesh`.
 
-second_mesh = adios4dolfinx.read_mesh(mesh_file, comm=MPI.COMM_WORLD, engine="BP4", time=3.3)
+second_mesh = adios4dolfinx.read_mesh(
+    mesh_file, comm=MPI.COMM_WORLD, backend="adios2", backend_args={"engine": "BP4"}, time=3.3
+)
 compute_volume(second_mesh, 3.3)
 
-first_mesh = adios4dolfinx.read_mesh(mesh_file, comm=MPI.COMM_WORLD, engine="BP4", time=1.5)
+first_mesh = adios4dolfinx.read_mesh(
+    mesh_file, comm=MPI.COMM_WORLD, backend="adios2", backend_args={"engine": "BP4"}, time=1.5
+)
 compute_volume(first_mesh, 1.5)
 
 # We observe that the volume of the mesh has changed, as we have perturbed the mesh

--- a/docs/writing_mesh_checkpoint.py
+++ b/docs/writing_mesh_checkpoint.py
@@ -102,7 +102,7 @@ def write_mesh(filename: Path):
     )
 
     # Write mesh checkpoint
-    adios4dolfinx.write_mesh(filename, mesh, engine="BP4")
+    adios4dolfinx.write_mesh(filename, mesh, backend="adios2", backend_args={"engine": "BP4"})
 
     # Inspect checkpoint on rank 0 with `bpls`
     if mesh.comm.rank == 0:
@@ -133,7 +133,11 @@ def read_mesh(filename: Path):
     import adios4dolfinx
 
     mesh = adios4dolfinx.read_mesh(
-        filename, comm=MPI.COMM_WORLD, engine="BP4", ghost_mode=dolfinx.mesh.GhostMode.none
+        filename,
+        comm=MPI.COMM_WORLD,
+        backend="adios2",
+        backend_args={"engine": "BP4"},
+        ghost_mode=dolfinx.mesh.GhostMode.none,
     )
     print_mesh_info(mesh)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ docs = [
     "ipykernel<7.0.0",     # Note: Remove once https://github.com/ipython/ipykernel/issues/1450 is in a release
     "sphinx-codeautolink",
     "adios4dolfinx[h5py]",
+    "sphinx_external_toc<1.1.0",
 ]
 all = ["adios4dolfinx[test,dev,docs]"]
 

--- a/src/adios4dolfinx/backends/__init__.py
+++ b/src/adios4dolfinx/backends/__init__.py
@@ -15,9 +15,11 @@ __all__ = ["FileMode", "IOBackend", "get_backend"]
 
 
 class FileMode(Enum):
-    append = 10
-    write = 20
-    read = 30
+    """Filen mode used for opening files."""
+
+    append = 10  #: Append data to file
+    write = 20  #: Write data to file
+    read = 30  #: Read data from file
 
 
 # See https://peps.python.org/pep-0544/#modules-as-implementations-of-protocols

--- a/src/adios4dolfinx/structures.py
+++ b/src/adios4dolfinx/structures.py
@@ -13,73 +13,85 @@ import numpy.typing as npt
 from dolfinx.graph import AdjacencyList
 
 """Internal library classes for storing mesh and function data"""
-__all__ = ["MeshData", "FunctionData"]
+__all__ = ["MeshData", "FunctionData", "ReadMeshData", "MeshTagsData"]
 
 
 @dataclass
 class MeshData:
-    # 2 dimensional array of node coordinates
+    """
+    Container for distributed mesh data that will be stored to disk
+    """
+
+    #: Two-dimensional array of node coordinates
     local_geometry: npt.NDArray[np.float32] | npt.NDArray[np.float64]
-    local_geometry_pos: tuple[int, int]  # Insert range on current process for geometry nodes
-    num_nodes_global: int  # Number of nodes in global geometry array
+    local_geometry_pos: tuple[int, int]  #: Insert range on current process for geometry nodes
+    num_nodes_global: int  #: Number of nodes in global geometry array
 
-    local_topology: npt.NDArray[np.int64]  # 2 dimensional connecitivty array for mesh topology
-    # Insert range on current process for topology
+    local_topology: npt.NDArray[np.int64]  #: Two-dimensional connectivity array for mesh topology
+    #: Insert range on current process for topology
     local_topology_pos: tuple[int, int]
-    num_cells_global: int  # NUmber of cells in global topology
+    num_cells_global: int  #: NUmber of cells in global topology
 
-    cell_type: str
-    degree: int
-    lagrange_variant: int
+    cell_type: str  #: The cell type
+    degree: int  #: Degree of underlying Lagrange element
+    lagrange_variant: int  #: Lagrange-variant of DOFs
 
     # Partitioning_information
-    store_partition: bool
-    partition_processes: int | None = None  # Number of processes in partition
-    ownership_array: npt.NDArray[np.int32] | None = None  # Ownership array for cells
-    ownership_offset: npt.NDArray[np.int32] | None = None  # Ownership offset for cells
+    store_partition: bool  #: Indicator if one should store mesh partitioning
+    partition_processes: int | None = None  #: Number of processes in partition
+    ownership_array: npt.NDArray[np.int32] | None = None  #: Ownership array for cells
+    ownership_offset: npt.NDArray[np.int32] | None = None  #: Ownership offset for cells
     partition_range: tuple[int, int] | None = (
-        None  # Local insert position for partitioning information
+        None  #: Local insert position for partitioning information
     )
-    partition_global: int | None = None
+    partition_global: int | None = None  #: Global size of partitioning array
 
 
 @dataclass
 class FunctionData:
-    cell_permutations: npt.NDArray[np.uint32]  # Cell permutations for dofmap
-    local_cell_range: tuple[int, int]  # Range of cells on current process
-    num_cells_global: int  # Number of cells in global topology
-    dofmap_array: npt.NDArray[np.int64]  # Local function dofmap (using global indices)
-    dofmap_offsets: npt.NDArray[np.int64]  # Global dofmap offsets
-    dofmap_range: tuple[int, int]  # Range of dofmap on current process
-    global_dofs_in_dofmap: int  # Number of entries in global dofmap
-    values: npt.NDArray[np.floating]  # Local function values
-    dof_range: tuple[int, int]  # Range of local function values
-    num_dofs_global: int  # Number of global function values
-    name: str  # Name of function
+    """
+    Container for distributed function data that will be written to file
+    """
+
+    cell_permutations: npt.NDArray[np.uint32]  #: Cell permutations for dofmap
+    local_cell_range: tuple[int, int]  #: Range of cells on current process
+    num_cells_global: int  #: Number of cells in global topology
+    dofmap_array: npt.NDArray[np.int64]  #: Local function dofmap (using global indices)
+    dofmap_offsets: npt.NDArray[np.int64]  #: Global dofmap offsets
+    dofmap_range: tuple[int, int]  #: Range of dofmap on current process
+    global_dofs_in_dofmap: int  #: Number of entries in global dofmap
+    values: npt.NDArray[np.floating]  #: Local function values
+    dof_range: tuple[int, int]  #: Range of local function values
+    num_dofs_global: int  #: Number of global function values
+    name: str  #: Name of function
 
 
 @dataclass
 class ReadMeshData:
+    """Container containing data that will be read into DOLFINx"""
+
+    #: Two-dimensional array containing global cell->node connectivity
     cells: npt.NDArray[np.int64]
-    cell_type: str
-    x: npt.NDArray[np.floating]
-    lvar: int
-    degree: int
+    cell_type: str  #: The cell type of the mesh
+    x: npt.NDArray[np.floating]  #: The mesh coordinates
+    lvar: int  #: The Lagrange variant
+    degree: int  #: The degree of the underlying Lagrange element
+    #: Partitioning information per cell on the process
     partition_graph: AdjacencyList | None = None
 
 
 @dataclass
 class MeshTagsData:
-    # Data used for both read/write
-    name: str
-    values: npt.NDArray
-    indices: npt.NDArray[np.int64]
-    dim: int
+    name: str  #: Name of tag
+    values: npt.NDArray  # Array of values
+    indices: npt.NDArray[np.int64]  # Global indices of the entities
+    dim: int  # Topological dimension of the entities
 
     # Optional entries (used for writing to disk)
-    num_entities_global: int | None = None
-    num_dofs_per_entity: int | None = None
+    num_entities_global: int | None = None  #: Global number of entities that will be written out
+    num_dofs_per_entity: int | None = None  #: Number of dofs per entity
+    #: Starting index in output array `(0<=local_start<num_entities_global)``
     local_start: int | None = None
 
     # Optional info to help visualization
-    cell_type: str | None = None
+    cell_type: str | None = None  #: The cell type


### PR DESCRIPTION
- Add migration guide from old to new API (Suggest to rename package to `io4dolfinx` - don't know if we would like to rename the repo as well or create a new one?)
- Add some docs on how to add a new backend
- Update some demos with new API
- Add upper bound on `sphinx_external_toc<1.1.0` (there seems to be some changes that doesn't work with the old jupyter-book)


For the migartion guide I added Tabs where you can switch between the different APIs (see below)

<img width="844" height="455" alt="Screenshot 2026-01-30 at 22 49 06" src="https://github.com/user-attachments/assets/7f1fa294-fb99-4c71-9d09-ef15608a14c8" />
